### PR TITLE
Support parent selection in breadcrumb navigation and new child creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ Please add issues to the [issue tracker](https://github.com/cfpb/wagtail-treemod
 General instructions on _how_ to contribute can be found in [CONTRIBUTING](CONTRIBUTING.md).
 
 ## Licensing
+
 1. [TERMS](TERMS.md)
 2. [LICENSE](LICENSE)
 3. [CFPB Source Code Policy](https://github.com/cfpb/source-code-policy/)

--- a/treemodeladmin/helpers.py
+++ b/treemodeladmin/helpers.py
@@ -1,8 +1,7 @@
 from django.contrib.admin.utils import quote
 from django.utils.encoding import force_text
 
-from wagtail.contrib.modeladmin.helpers import ButtonHelper
-from wagtail.contrib.modeladmin.helpers import AdminURLHelper
+from wagtail.contrib.modeladmin.helpers import AdminURLHelper, ButtonHelper
 
 
 class TreeAdminURLHelper(AdminURLHelper):

--- a/treemodeladmin/helpers.py
+++ b/treemodeladmin/helpers.py
@@ -1,3 +1,6 @@
+from django.contrib.admin.utils import quote
+from django.utils.encoding import force_text
+
 from wagtail.contrib.modeladmin.helpers import ButtonHelper
 from wagtail.contrib.modeladmin.helpers import AdminURLHelper
 
@@ -8,7 +11,28 @@ class TreeAdminURLHelper(AdminURLHelper):
         return '{create_url}?{parent_field}={parent_pk}'.format(
             create_url=self.create_url,
             parent_field=parent_field,
-            parent_pk=parent_pk
+            parent_pk=quote(parent_pk)
+        )
+
+    def get_index_url_with_parent(self, parent_field, parent_pk):
+        return '{index_url}?{parent_field}={parent_pk}'.format(
+            index_url=self.index_url,
+            parent_field=parent_field,
+            parent_pk=quote(parent_pk)
+        )
+
+    def crumb(self, parent_field=None, parent_instance=None):
+        if parent_field is not None and parent_instance is not None:
+            index_url = self.get_index_url_with_parent(
+                parent_field,
+                parent_instance.pk
+            )
+        else:
+            index_url = self.index_url
+
+        return (
+            index_url,
+            force_text(self.opts.verbose_name_plural)
         )
 
 

--- a/treemodeladmin/helpers.py
+++ b/treemodeladmin/helpers.py
@@ -1,4 +1,15 @@
 from wagtail.contrib.modeladmin.helpers import ButtonHelper
+from wagtail.contrib.modeladmin.helpers import AdminURLHelper
+
+
+class TreeAdminURLHelper(AdminURLHelper):
+
+    def get_create_url_with_parent(self, parent_field, parent_pk):
+        return '{create_url}?{parent_field}={parent_pk}'.format(
+            create_url=self.create_url,
+            parent_field=parent_field,
+            parent_pk=parent_pk
+        )
 
 
 class TreeButtonHelper(ButtonHelper):
@@ -7,3 +18,14 @@ class TreeButtonHelper(ButtonHelper):
         return super(TreeButtonHelper, self).add_button(
             classnames_add=['button-small']
         )
+
+    def get_add_button_with_parent(self, parent_field, parent_pk,
+                                   classnames_add=None,
+                                   classnames_exclude=None):
+        add_button = self.add_button(classnames_add=classnames_add,
+                                     classnames_exclude=classnames_exclude)
+        add_button['url'] = self.url_helper.get_create_url_with_parent(
+            parent_field,
+            parent_pk
+        )
+        return add_button

--- a/treemodeladmin/options.py
+++ b/treemodeladmin/options.py
@@ -1,7 +1,12 @@
 from wagtail.contrib.modeladmin.options import ModelAdmin
 
 from treemodeladmin.helpers import TreeAdminURLHelper, TreeButtonHelper
-from treemodeladmin.views import TreeCreateView, TreeIndexView
+from treemodeladmin.views import (
+    TreeCreateView,
+    TreeDeleteView,
+    TreeEditView,
+    TreeIndexView,
+)
 
 
 class TreeModelAdmin(ModelAdmin):
@@ -11,6 +16,8 @@ class TreeModelAdmin(ModelAdmin):
     parent_field = None
     index_view_class = TreeIndexView
     create_view_class = TreeCreateView
+    delete_view_class = TreeDeleteView
+    edit_view_class = TreeEditView
     index_template_name = 'treemodeladmin/index.html'
     button_helper_class = TreeButtonHelper
     url_helper_class = TreeAdminURLHelper

--- a/treemodeladmin/options.py
+++ b/treemodeladmin/options.py
@@ -1,7 +1,7 @@
 from wagtail.contrib.modeladmin.options import ModelAdmin
 
-from treemodeladmin.helpers import TreeButtonHelper
-from treemodeladmin.views import TreeIndexView
+from treemodeladmin.helpers import TreeAdminURLHelper, TreeButtonHelper
+from treemodeladmin.views import TreeIndexView, TreeCreateView
 
 
 class TreeModelAdmin(ModelAdmin):
@@ -10,8 +10,10 @@ class TreeModelAdmin(ModelAdmin):
     child_instance = None
     parent_field = None
     index_view_class = TreeIndexView
+    create_view_class = TreeCreateView
     index_template_name = 'treemodeladmin/index.html'
     button_helper_class = TreeButtonHelper
+    url_helper_class = TreeAdminURLHelper
 
     def __init__(self, parent=None):
         super(TreeModelAdmin, self).__init__(parent=parent)

--- a/treemodeladmin/options.py
+++ b/treemodeladmin/options.py
@@ -1,7 +1,7 @@
 from wagtail.contrib.modeladmin.options import ModelAdmin
 
 from treemodeladmin.helpers import TreeAdminURLHelper, TreeButtonHelper
-from treemodeladmin.views import TreeIndexView, TreeCreateView
+from treemodeladmin.views import TreeCreateView, TreeIndexView
 
 
 class TreeModelAdmin(ModelAdmin):

--- a/treemodeladmin/templates/treemodeladmin/includes/header.html
+++ b/treemodeladmin/templates/treemodeladmin/includes/header.html
@@ -8,7 +8,7 @@
       <div class="col">
         {% block h1 %}<h1 {% if view.header_icon %}class="icon icon-{{ view.header_icon }}"{% endif %}>{{ view.get_page_title }}<span></span></h1>{% endblock %}
         {% include 'modeladmin/includes/button.html' with button=view.get_parent_edit_button %}
-        {% include 'modeladmin/includes/button.html' with button=view.button_helper.add_button %}
+        {% include 'modeladmin/includes/button.html' with button=view.get_add_button_with_parent %}
       </div>
       {% block search %}{% search_form %}{% endblock %}
     </div>

--- a/treemodeladmin/templates/treemodeladmin/includes/tree_result_row.html
+++ b/treemodeladmin/templates/treemodeladmin/includes/tree_result_row.html
@@ -5,7 +5,7 @@
     {% endfor %}
     {% if children.count > 0 %}
     <td class="children">
-        <a class="icon text-replace icon-arrow-right" title="Explore {{ obj }}'s {{ view.child_name_plural }}" href="{{ child_index_url }}?{{child_filter}}">Explore {{ obj }}'s {{ view.child_name_plural }}</a>
+        <a class="icon text-replace icon-arrow-right" title="Explore {{ obj }}'s {{ view.child_name_plural }}" href="{{ child_index_url }}">Explore {{ obj }}'s {{ view.child_name_plural }}</a>
     </td>
     {% else %}
     <td class="no-children">

--- a/treemodeladmin/templates/treemodeladmin/index.html
+++ b/treemodeladmin/templates/treemodeladmin/index.html
@@ -1,77 +1,31 @@
-{% extends "wagtailadmin/base.html" %}
+{% extends "modeladmin/index.html" %}
 {% load i18n modeladmin_tags treemodeladmin_tags %}
 
-{% block titletag %}{{ view.get_meta_title }}{% endblock %}
-
-{% block css %}
-    {{ block.super }}
-    {{ view.media.css }}
+{% block header %}
+    {% include "treemodeladmin/includes/header.html" %}
 {% endblock %}
 
-{% block extra_js %}
-    {{ view.media.js }}
-{% endblock %}
-
-{% block content %}
-    {% block header %}
-        {% include "treemodeladmin/includes/header.html" %}
-    {% endblock %}
-
-    {% block content_main %}
-        <div>
-            <div class="row">
-                {% block content_cols %}
-
-                    {% block filters %}
-                        {% if view.has_filters and all_count %}
-                        <div class="changelist-filter col3">
-                            <h2>{% trans 'Filter' %}</h2>
-                            {% for spec in view.filter_specs %}{% admin_list_filter view spec %}{% endfor %}
-                        </div>
-                        {% endif %}
-                    {% endblock %}
-
-                    <div class="result-list {% if view.has_filters and all_count %}col9{% else %}col12{% endif %}">
-                        {% block result_list %}
-                            {% if not all_count %}
-                                <div class="nice-padding" style="margin-top:30px;">
-                                    {% if no_valid_parents %}
-                                        <p>{% blocktrans with view.verbose_name_plural as name %}No {{ name }} have been created yet. One of the following must be created before you can add any {{ name }}:{% endblocktrans %}</p>
-                                        <ul>
-                                            {% for type in required_parent_types %}<li><b>{{ type|title }}</b></li>{% endfor %}
-                                        </ul>
-                                    {% else %}
-                                        <p>{% blocktrans with view.verbose_name_plural as name %}No {{ name }} have been created yet.{% endblocktrans %}
-                                        {% if user_can_create %}
-                                            {% blocktrans with view.create_url as url %}
-                                                Why not <a href="{{ url }}">add one</a>?
-                                            {% endblocktrans %}
-                                        {% endif %}</p>
-                                    {% endif %}
-                                </div>
-                            {% elif view.has_child %}
-                                {% tree_result_list %}
-                            {% else %}
-                                {% result_list %}
-                            {% endif %}
-                        {% endblock %}
-                    </div>
-
-                    {% block pagination %}
-                        <div class="pagination {% if view.has_filters and all_count %}col9{% else %}col12{% endif %}">
-                            <p>{% blocktrans with page_obj.number as current_page and paginator.num_pages as num_pages %}Page {{ current_page }} of {{ num_pages }}.{% endblocktrans %}</p>
-                            {% if paginator.num_pages > 1 %}
-                                <ul>
-                                    {% pagination_link_previous page_obj view %}
-                                    {% pagination_link_next page_obj view %}
-                                </ul>
-                            {% endif %}
-                        </div>
-                    {% endblock %}
-
-                {% endblock %}
-            </div>
+{% block result_list %}
+    {% if not all_count %}
+        <div class="nice-padding" style="margin-top:30px;">
+            {% if no_valid_parents %}
+                <p>{% blocktrans with view.verbose_name_plural as name %}No {{ name }} have been created yet. One of the following must be created before you can add any {{ name }}:{% endblocktrans %}</p>
+                <ul>
+                    {% for type in required_parent_types %}<li><b>{{ type|title }}</b></li>{% endfor %}
+                </ul>
+            {% else %}
+                <p>{% blocktrans with view.verbose_name_plural as name %}No {{ name }} have been created yet.{% endblocktrans %}
+                {% if user_can_create %}
+                    {% blocktrans with view.create_url as url %}
+                        Why not <a href="{{ url }}">add one</a>?
+                    {% endblocktrans %}
+                {% endif %}</p>
+            {% endif %}
         </div>
-    {% endblock %}
-
+    {% elif view.has_child %}
+        {% tree_result_list %}
+    {% else %}
+        {% result_list %}
+    {% endif %}
 {% endblock %}
+

--- a/treemodeladmin/templatetags/treemodeladmin_tags.py
+++ b/treemodeladmin/templatetags/treemodeladmin_tags.py
@@ -24,13 +24,16 @@ def tree_result_row_display(context, index):
     context = result_row_display(context, index)
     obj = context['object_list'][index]
     view = context['view']
+    child_url_helper = view.child_url_helper
 
     if view.has_child_admin:
         context.update({
             'children': view.get_children(obj),
-            'child_index_url': view.child_url_helper.index_url,
+            'child_index_url': child_url_helper.index_url,
             'child_filter': view.get_child_filter(quote(obj.pk)),
-            'child_create_url': view.child_url_helper.create_url,
+            'child_create_url': child_url_helper.get_create_url_with_parent(
+                view.child_model_admin.parent_field, obj.pk
+            ),
         })
 
     return context

--- a/treemodeladmin/templatetags/treemodeladmin_tags.py
+++ b/treemodeladmin/templatetags/treemodeladmin_tags.py
@@ -1,4 +1,3 @@
-from django.contrib.admin.utils import quote
 from django.template import Library
 
 from wagtail.contrib.modeladmin.templatetags.modeladmin_tags import (
@@ -29,8 +28,9 @@ def tree_result_row_display(context, index):
     if view.has_child_admin:
         context.update({
             'children': view.get_children(obj),
-            'child_index_url': child_url_helper.index_url,
-            'child_filter': view.get_child_filter(quote(obj.pk)),
+            'child_index_url': child_url_helper.get_index_url_with_parent(
+                view.child_model_admin.parent_field, obj.pk
+            ),
             'child_create_url': child_url_helper.get_create_url_with_parent(
                 view.child_model_admin.parent_field, obj.pk
             ),

--- a/treemodeladmin/tests/test_views.py
+++ b/treemodeladmin/tests/test_views.py
@@ -1,5 +1,4 @@
 from django.test import TestCase
-from unittest import skip
 
 from wagtail.tests.utils import WagtailTestUtils
 
@@ -98,6 +97,7 @@ class TestBookIndexView(TestCase, WagtailTestUtils):
                 ('/admin/treemodeladmintest/book/?author=1', 'books')
             ]
         )
+
 
 class TestBookCreateView(TestCase, WagtailTestUtils):
     fixtures = ['treemodeladmin_test.json']

--- a/treemodeladmin/tests/test_views.py
+++ b/treemodeladmin/tests/test_views.py
@@ -74,8 +74,13 @@ class TestBookIndexView(TestCase, WagtailTestUtils):
         response = self.get(author=1)
         self.assertFalse(response.context['view'].has_child_admin)
 
+    def test_book_listing_parent_edit_link_filtered(self):
+        response = self.get(author=1)
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, '/author/edit/1')
+
     def test_breadcrumbs(self):
-        resposne = self.get(author=1)
+        resposne = self.get()
         self.assertEqual(
             list(resposne.context['view'].breadcrumbs),
             [
@@ -84,6 +89,15 @@ class TestBookIndexView(TestCase, WagtailTestUtils):
             ]
         )
 
+    def test_breadcrumbs_with_parent(self):
+        resposne = self.get(author=1)
+        self.assertEqual(
+            list(resposne.context['view'].breadcrumbs),
+            [
+                ('/admin/treemodeladmintest/author/', 'authors'),
+                ('/admin/treemodeladmintest/book/?author=1', 'books')
+            ]
+        )
 
 class TestBookCreateView(TestCase, WagtailTestUtils):
     fixtures = ['treemodeladmin_test.json']

--- a/treemodeladmin/tests/test_views.py
+++ b/treemodeladmin/tests/test_views.py
@@ -1,4 +1,5 @@
 from django.test import TestCase
+from unittest import skip
 
 from wagtail.tests.utils import WagtailTestUtils
 
@@ -16,8 +17,18 @@ class TestAuthorIndexView(TestCase, WagtailTestUtils):
         response = self.get()
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.context['result_count'], 4)
-        self.assertContains(response, "Explore J. R. R. Tolkien's books")
-        self.assertContains(response, "Add a J. R. Hartley book")
+
+    def test_explore_link(self):
+        response = self.get()
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'Explore J. R. R. Tolkien\'s books')
+        self.assertContains(response, '/book/?author=1')
+
+    def test_add_child_link(self):
+        response = self.get()
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'Add a J. R. Hartley book')
+        self.assertContains(response, '/book/create/?author=4')
 
     def test_has_child_admin(self):
         response = self.get()
@@ -54,6 +65,11 @@ class TestBookIndexView(TestCase, WagtailTestUtils):
             'J. R. R. Tolkien'
         )
 
+    def test_book_listing_add_link_filtered(self):
+        response = self.get(author=1)
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, '/book/create/?author=1')
+
     def test_has_child_admin(self):
         response = self.get(author=1)
         self.assertFalse(response.context['view'].has_child_admin)
@@ -67,3 +83,19 @@ class TestBookIndexView(TestCase, WagtailTestUtils):
                 ('/admin/treemodeladmintest/book/', 'books')
             ]
         )
+
+
+class TestBookCreateView(TestCase, WagtailTestUtils):
+    fixtures = ['treemodeladmin_test.json']
+
+    def setUp(self):
+        self.user = self.login()
+
+    def get(self, **params):
+        return self.client.get('/admin/treemodeladmintest/book/create/',
+                               params)
+
+    def test_book_creation_with_initial_author(self):
+        response = self.get(author=1)
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'value="1" selected')

--- a/treemodeladmin/views.py
+++ b/treemodeladmin/views.py
@@ -87,7 +87,8 @@ class TreeIndexView(TreeViewParentMixin, IndexView):
             return None
         parent_button_helper_class = \
             self.parent_model_admin.get_button_helper_class()
-        parent_button_helper = parent_button_helper_class(self, self.request)
+        parent_button_helper = parent_button_helper_class(
+            self.parent_model_admin, self.request)
         return parent_button_helper.edit_button(
             self.parent_instance.pk,
             classnames_add=['button-secondary', 'button-small']

--- a/treemodeladmin/views.py
+++ b/treemodeladmin/views.py
@@ -1,12 +1,8 @@
 from django.contrib.admin.utils import unquote
-from django.contrib.auth.decorators import login_required
-from django.core.exceptions import PermissionDenied
 from django.shortcuts import get_object_or_404
-from django.utils.decorators import method_decorator
-from django.utils.encoding import force_text
 from django.utils.functional import cached_property
 
-from wagtail.contrib.modeladmin.views import IndexView, CreateView
+from wagtail.contrib.modeladmin.views import CreateView, IndexView
 
 
 class TreeViewParentMixin(object):


### PR DESCRIPTION
This PR adds support for maintaining parent selection while navigating the tree in breadcrumbs and when creating a new child.

## Additions

- Clicking on a model name in the breadcrumbs while having a parent selected will maintain the parent selection throughout the tree.
- Creating a new child from a page with a parent selection (either the + button on an empty parent or the "Add {Model Name}" button) will have that field in the creation form filled out with the selected parent. 
- Editing a child will redirect to the parent-filtered listing page.
- Deleting a child will redirect to the parent-filtered listing page.

## Changes

- Fixed the "Edit" button under the parent name. Previously it was editing the child object with the parent's primary key.
- Refactored some of the TreeIndexView parent logic into a mixin class.
- Refactored the breadcrumb logic to make use of a URL helper subclass.
- Changed `treemodeladmin/index.html` to extend `modeladmin/index.html` and removed all the blocks that aren't modified by TreeModelAdmin.

## Testing

1. Standlone (thanks, @higs4281!):

   ```shell
   export DJANGO_SETTINGS_MODULE=treemodeladmin.tests.settings
   export PYTHONPATH='[PATH TO PROJECT]'
   django-admin.py migrate
   django-admin.py loaddata treemodeladmin_test
   django-admin.py runserver
   ```

   Then visit http://localhost:8000/admin. Author will be available under the "TreeModelAdmin Test" menu item.

2. With cfgov-refresh and docker:

   ```shell
   git checkout origin/treemodeladmin
   docker-compose build python
   docker-compose up
   ```

   Then visit http://localhost:8000/admin. The Regulations 3000 models will be navigable via TreeModelAdmin under the "Regulations" menu item.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
