### PR TITLE
Fix parent breadcrumbs

### DIFF
--- a/treemodeladmin/options.py
+++ b/treemodeladmin/options.py
@@ -13,7 +13,7 @@ class TreeModelAdmin(ModelAdmin):
     child_field = None
     child_model_admin = None
     child_instance = None
-    parent_field = None
+    parent_field = ''
     index_view_class = TreeIndexView
     create_view_class = TreeCreateView
     delete_view_class = TreeDeleteView

--- a/treemodeladmin/tests/test_views.py
+++ b/treemodeladmin/tests/test_views.py
@@ -73,7 +73,7 @@ class TestBookIndexView(TestCase, WagtailTestUtils):
 
     def test_has_child_admin(self):
         response = self.get(author=1)
-        self.assertFalse(response.context['view'].has_child_admin)
+        self.assertTrue(response.context['view'].has_child_admin)
 
     def test_book_listing_parent_edit_link_filtered(self):
         response = self.get(author=1)
@@ -169,12 +169,12 @@ class TestBookDeleteView(TestCase, WagtailTestUtils):
         )
 
     def test_post(self):
-        response = self.post(1)
+        response = self.post(2)
         self.assertRedirects(
             response,
             '/admin/treemodeladmintest/book/?author=1'
         )
-        self.assertFalse(Book.objects.filter(id=1).exists())
+        self.assertFalse(Book.objects.filter(id=2).exists())
 
 
 class TestAuthorDeleteView(TestCase, WagtailTestUtils):
@@ -205,3 +205,37 @@ class TestAuthorDeleteView(TestCase, WagtailTestUtils):
         response = self.post(4)
         self.assertRedirects(response, '/admin/treemodeladmintest/author/')
         self.assertFalse(Author.objects.filter(id=4).exists())
+
+
+class TestVolumeIndexView(TestCase, WagtailTestUtils):
+    fixtures = ['treemodeladmin_test.json']
+
+    def setUp(self):
+        self.user = self.login()
+
+    def get(self, **params):
+        return self.client.get('/admin/treemodeladmintest/volume/', params)
+
+    def test_has_child_admin(self):
+        response = self.get()
+        self.assertFalse(response.context['view'].has_child_admin)
+
+    def test_volume_listing_filtered(self):
+        response = self.get(book=1)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.context['result_count'], 1)
+        self.assertEqual(
+            response.context['view'].get_page_title(),
+            'The Lord of the Rings'
+        )
+
+    def test_breadcrumbs_with_parents(self):
+        resposne = self.get(book=1)
+        self.assertEqual(
+            list(resposne.context['view'].breadcrumbs),
+            [
+                ('/admin/treemodeladmintest/author/', 'authors'),
+                ('/admin/treemodeladmintest/book/?author=1', 'books'),
+                ('/admin/treemodeladmintest/volume/?book=1', 'volumes')
+            ]
+        )

--- a/treemodeladmin/tests/treemodeladmintest/fixtures/treemodeladmin_test.json
+++ b/treemodeladmin/tests/treemodeladmintest/fixtures/treemodeladmin_test.json
@@ -58,5 +58,13 @@
             "title": "The Chronicles of Narnia",
             "author_id": 3
         }
+    },
+    {
+        "pk": 1,
+        "model": "treemodeladmintest.volume",
+        "fields": {
+            "title": "The Fellowship of the Ring",
+            "book_id": 1
+        }
     }
 ]

--- a/treemodeladmin/tests/treemodeladmintest/migrations/0001_initial.py
+++ b/treemodeladmin/tests/treemodeladmintest/migrations/0001_initial.py
@@ -26,4 +26,12 @@ class Migration(migrations.Migration):
                 ('author', models.ForeignKey(to='treemodeladmintest.Author', on_delete=django.db.models.deletion.PROTECT)),
             ],
         ),
+        migrations.CreateModel(
+            name='Volume',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('title', models.CharField(max_length=255)),
+                ('book', models.ForeignKey(to='treemodeladmintest.Book', on_delete=django.db.models.deletion.PROTECT)),
+            ],
+        ),
     ]

--- a/treemodeladmin/tests/treemodeladmintest/models.py
+++ b/treemodeladmin/tests/treemodeladmintest/models.py
@@ -14,3 +14,11 @@ class Book(models.Model):
 
     def __str__(self):
         return self.title
+
+
+class Volume(models.Model):
+    book = models.ForeignKey(Book, on_delete=models.PROTECT)
+    title = models.CharField(max_length=255)
+
+    def __str__(self):
+        return self.title

--- a/treemodeladmin/tests/treemodeladmintest/wagtail_hooks.py
+++ b/treemodeladmin/tests/treemodeladmintest/wagtail_hooks.py
@@ -4,11 +4,18 @@ from wagtail.contrib.modeladmin.options import (
 )
 
 from treemodeladmin.options import TreeModelAdmin
-from treemodeladmin.tests.treemodeladmintest.models import Author, Book
+from treemodeladmin.tests.treemodeladmintest.models import Author, Book, Volume
+
+
+class VolumeModelAdmin(TreeModelAdmin):
+    model = Volume
+    parent_field = 'book'
 
 
 class BookModelAdmin(TreeModelAdmin):
     model = Book
+    child_field = 'volume_set'
+    child_model_admin = VolumeModelAdmin
     parent_field = 'author'
 
 

--- a/treemodeladmin/views.py
+++ b/treemodeladmin/views.py
@@ -69,12 +69,12 @@ class TreeViewParentMixin(object):
             )
 
             if model_admin.has_parent():
+                model_admin = model_admin.parent
                 parent_instance = getattr(
                     parent_instance,
                     model_admin.parent_field,
                     None
                 )
-                model_admin = model_admin.parent
             else:
                 model_admin = None
 


### PR DESCRIPTION
Parent breadcrumbs were broken below the first set of children (basically after the first loop). This PR fixes it.

## Changes

- Breadcrumbs two-levels or deeper now include the ancestral parent filter in the link
