### PR TITLE
Vertically align content in admin table

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     long_description=long_description,
     long_description_content_type='text/markdown',
     license='CC0',
-    version='1.0.1',
+    version='1.0.2',
     include_package_data=True,
     packages=find_packages(),
     package_data={

--- a/treemodeladmin/static/treemodeladmin/css/index.css
+++ b/treemodeladmin/static/treemodeladmin/css/index.css
@@ -19,3 +19,7 @@ header .button.bicolor {
 .result-list.col12 {
     padding: 0;
 }
+
+.result-list td:not([class$=children]) {
+  vertical-align: top;
+}


### PR DESCRIPTION
Align content in admin tables to the top of cells (except the final "children" cells so that the arrow/plus icons stay centered).

## Changes

- Align admin content to top of cells.

## Screenshots

Before:

<img width="1284" alt="screen shot 2018-05-24 at 5 37 25 pm" src="https://user-images.githubusercontent.com/1060248/40515006-24b0fd92-5f79-11e8-86f0-1e4080c980c4.png">

After:

<img width="1275" alt="screen shot 2018-05-24 at 5 36 31 pm" src="https://user-images.githubusercontent.com/1060248/40514964-057930e8-5f79-11e8-9712-c2cdf26683f0.png">


## Notes

- Wagtail core [hardcodes](https://github.com/wagtail/wagtail/search?q=valign&unscoped_q=valign) vertical alignment in the templates instead of using CSS. CSS seems preferable.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: