### PR TITLE
Make breadcrumbs show specific parents when they exist

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     long_description=long_description,
     long_description_content_type='text/markdown',
     license='CC0',
-    version='1.0.2',
+    version='1.0.3',
     include_package_data=True,
     packages=find_packages(),
     package_data={

--- a/treemodeladmin/helpers.py
+++ b/treemodeladmin/helpers.py
@@ -20,7 +20,8 @@ class TreeAdminURLHelper(AdminURLHelper):
             parent_pk=quote(parent_pk)
         )
 
-    def crumb(self, parent_field=None, parent_instance=None):
+    def crumb(self, parent_field=None, parent_instance=None,
+              specific_instance=None):
         if parent_field is not None and parent_instance is not None:
             index_url = self.get_index_url_with_parent(
                 parent_field,
@@ -29,9 +30,14 @@ class TreeAdminURLHelper(AdminURLHelper):
         else:
             index_url = self.index_url
 
+        if specific_instance is not None:
+            crumb_text = force_text(specific_instance)
+        else:
+            crumb_text = force_text(self.opts.verbose_name_plural)
+
         return (
             index_url,
-            force_text(self.opts.verbose_name_plural)
+            crumb_text
         )
 
 

--- a/treemodeladmin/tests/test_views.py
+++ b/treemodeladmin/tests/test_views.py
@@ -43,6 +43,26 @@ class TestAuthorIndexView(TestCase, WagtailTestUtils):
         )
 
 
+class TestAuthorCreateView(TestCase, WagtailTestUtils):
+    fixtures = ['treemodeladmin_test.json']
+
+    def setUp(self):
+        self.user = self.login()
+
+    def post(self, post_data):
+        return self.client.post('/admin/treemodeladmintest/author/create/',
+                                post_data)
+
+    def test_create_redirects_to_plain_index(self):
+        response = self.post({
+            'name': 'P. G. Wodehouse',
+        })
+
+        # Should redirect back to
+        self.assertRedirects(response,
+                             '/admin/treemodeladmintest/author/')
+
+
 class TestBookIndexView(TestCase, WagtailTestUtils):
     fixtures = ['treemodeladmin_test.json']
 
@@ -95,7 +115,7 @@ class TestBookIndexView(TestCase, WagtailTestUtils):
         self.assertEqual(
             list(resposne.context['view'].breadcrumbs),
             [
-                ('/admin/treemodeladmintest/author/', 'authors'),
+                ('/admin/treemodeladmintest/author/', 'J. R. R. Tolkien'),
                 ('/admin/treemodeladmintest/book/?author=1', 'books')
             ]
         )
@@ -234,8 +254,9 @@ class TestVolumeIndexView(TestCase, WagtailTestUtils):
         self.assertEqual(
             list(resposne.context['view'].breadcrumbs),
             [
-                ('/admin/treemodeladmintest/author/', 'authors'),
-                ('/admin/treemodeladmintest/book/?author=1', 'books'),
+                ('/admin/treemodeladmintest/author/', 'J. R. R. Tolkien'),
+                ('/admin/treemodeladmintest/book/?author=1',
+                 'The Lord of the Rings'),
                 ('/admin/treemodeladmintest/volume/?book=1', 'volumes')
             ]
         )

--- a/treemodeladmin/views.py
+++ b/treemodeladmin/views.py
@@ -57,6 +57,7 @@ class TreeViewParentMixin(object):
     @property
     def breadcrumbs(self):
         parent_instance = self.parent_instance
+        specific_instance = None
         model_admin = self.model_admin
 
         breadcrumbs = []
@@ -65,12 +66,14 @@ class TreeViewParentMixin(object):
             breadcrumbs.append(
                 model_admin.url_helper.crumb(
                     parent_field=model_admin.parent_field,
-                    parent_instance=parent_instance
+                    parent_instance=parent_instance,
+                    specific_instance=specific_instance
                 )
             )
 
             if model_admin.has_parent():
                 model_admin = model_admin.parent
+                specific_instance = parent_instance
                 parent_instance = getattr(
                     parent_instance,
                     model_admin.parent_field,


### PR DESCRIPTION
This PR changes the way TreeModelAdmin generates breadcrumbs. Where before the crumbs would include only the plural name of the parent models, even if we're "inside" a particular parent. This PR changes the breadcrumbs to display `str(parent_instance)` instead of the plural name of the model.

The test app before:

![image](https://user-images.githubusercontent.com/10562538/41304623-aad7d9bc-6e3e-11e8-9670-b420af3ed4ac.png)

The test app after:

![image](https://user-images.githubusercontent.com/10562538/41304586-9a033e92-6e3e-11e8-82b6-509910baf8ad.png)

I've bumped the version number in `setup.py` in anticipation of releasing this.

## Checklist

- [X] PR has an informative and human-readable title
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [X] Passes all existing automated tests
- [X] Any _change_ in functionality is tested
- [X] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [X] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
