### PR TITLE
Fix hover bug

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,15 +5,15 @@ matrix:
   include:
     - env: TOXENV=lint
       python: 3.6
-    - env: TOXENV=py27-dj18-wag113
-      python: 2.7
     - env: TOXENV=py27-dj111-wag113
       python: 2.7
-    - env: TOXENV=py36-dj18-wag113
-      python: 3.6
     - env: TOXENV=py36-dj111-wag113
       python: 3.6
     - env: TOXENV=py36-dj20-wag20
+      python: 3.6
+    - env: TOXENV=py36-dj20-wag21
+      python: 3.6
+    - env: TOXENV=py36-dj20-wag22
       python: 3.6
 
 install:

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Wagtail-TreeModelAdmin is an extension for Wagtail's [ModelAdmin](http://docs.wa
 
 ## Dependencies
 
-- Django 1.8+ (including Django 2.0)
+- Django 1.11+ (including Django 2.0)
 - Wagtail 1.13+ (including Wagtail 2.0)
 - Python 2.7+, 3.6+
 

--- a/setup.py
+++ b/setup.py
@@ -6,8 +6,8 @@ with open('README.md') as f:
 
 
 install_requires = [
-    'Django>=1.8,<2.1',
-    'wagtail>=1.13,<2.1',
+    'Django>=1.11,<2.1',
+    'wagtail>=1.13,<2.3',
 ]
 
 
@@ -43,8 +43,8 @@ setup(
     classifiers=[
         'Framework :: Django',
         'Framework :: Django :: 1.11',
-        'Framework :: Django :: 1.8',
         'Framework :: Django :: 2.0',
+        'Framework :: Django :: 2.1',
         'Framework :: Wagtail',
         'Framework :: Wagtail :: 1',
         'Framework :: Wagtail :: 2',

--- a/tox.ini
+++ b/tox.ini
@@ -2,8 +2,8 @@
 skipsdist=True
 envlist=
     lint,
-    py{27,36}-dj{18,111}-wag{113},
-    py{36}-dj{20}-wag{20}
+    py{27,36}-dj{111}-wag{113},
+    py{36}-dj{20}-wag{20,21,22}
 
 [testenv]
 install_command=pip install -e ".[testing]" -U {opts} {packages}
@@ -19,11 +19,12 @@ basepython=
     py36: python3.6
 
 deps=
-    dj18: Django>=1.8,<1.9
     dj111: Django>=1.11,<1.12
     dj20: Django>=2.0,<2.1
     wag113: wagtail>=1.13,<1.14
     wag20: wagtail>=2.0,<2.1
+    wag21: wagtail>=2.1,<2.2
+    wag22: wagtail>=2.2,<2.3
 
 [testenv:lint]
 basepython=python3.6

--- a/treemodeladmin/options.py
+++ b/treemodeladmin/options.py
@@ -57,7 +57,10 @@ class TreeModelAdmin(ModelAdmin):
             return self.parent_field
 
     def get_index_view_extra_css(self):
-        css = ['treemodeladmin/css/index.css']
+        css = [
+            'wagtailmodeladmin/css/index.css',
+            'treemodeladmin/css/index.css'
+        ]
         css.extend(self.index_view_extra_css)
         return css
 

--- a/treemodeladmin/static/treemodeladmin/css/index.css
+++ b/treemodeladmin/static/treemodeladmin/css/index.css
@@ -20,6 +20,10 @@ header .button.bicolor {
     padding: 0;
 }
 
-.result-list td:not([class$=children]) {
-  vertical-align: top;
+.result-list.col12 tbody td.children:last-child {
+    padding-right: 0;
+}
+
+.listing td.children {
+    vertical-align: middle;
 }

--- a/treemodeladmin/tests/test_options.py
+++ b/treemodeladmin/tests/test_options.py
@@ -98,13 +98,16 @@ class TestTreeModelAdmin(TestCase):
     def test_get_index_view_extra_css(self):
         self.assertEqual(
             self.author_model_admin.get_index_view_extra_css(),
-            ['treemodeladmin/css/index.css', 'authors.css']
+            ['wagtailmodeladmin/css/index.css',
+             'treemodeladmin/css/index.css',
+             'authors.css']
         )
 
     def test_get_index_view_extra_css_none(self):
         self.assertEqual(
             self.plain_model_admin.get_index_view_extra_css(),
-            ['treemodeladmin/css/index.css']
+            ['wagtailmodeladmin/css/index.css',
+             'treemodeladmin/css/index.css']
         )
 
     def test_get_admin_urls_for_registration_child(self):

--- a/treemodeladmin/tests/urls.py
+++ b/treemodeladmin/tests/urls.py
@@ -1,9 +1,11 @@
 from django.conf.urls import include, url
 
+import wagtail
 
-try:
+
+if wagtail.VERSION >= (2, 0):
     from wagtail.admin import urls as wagtailadmin_urls
-except ImportError:
+else:
     from wagtail.wagtailadmin import urls as wagtailadmin_urls
 
 

--- a/treemodeladmin/views.py
+++ b/treemodeladmin/views.py
@@ -13,9 +13,9 @@ from wagtail.contrib.modeladmin.views import (
 )
 
 
-try:
+try:  # pragma: no cover
     from wagtail.admin import messages
-except ImportError:
+except ImportError:  # pragma: no cover
     from wagtail.wagtailadmin import messages
 
 


### PR DESCRIPTION
This PR fixes #8, where action buttons only appear when their column is hovered. The standard Wagtail ModelAdmin behavior is to show action buttons whenever the entire row is hovered. This is fixed by ensuring that we inherit ModelAdmin's default index CSS. 

This PR also includes some minor changes to the TreeModelAdmin CSS that are required now that we're inheriting ModelAdmin's CSS.

I've also included support for Django 2.1 and Wagtail 2.1 and 2.2.