### PR TITLE
Fix vertical alignment of "no children" icon

### DIFF
--- a/treemodeladmin/static/treemodeladmin/css/index.css
+++ b/treemodeladmin/static/treemodeladmin/css/index.css
@@ -24,6 +24,6 @@ header .button.bicolor {
     padding-right: 0;
 }
 
-.listing td.children {
+.listing td.children, .listing td.no-children {
     vertical-align: middle;
 }


### PR DESCRIPTION
This change alters the CSS to properly vertically center the plus sign icon that appears when a menu item has no children. Currently this icon is aligned to the top, which feels wrong and is inconsistent with how this icon appears in the Wagtail page browser.

## Screenshots

Before:

![image](https://user-images.githubusercontent.com/654645/71595881-5e014e80-2b0b-11ea-9771-f2c8d6ea0ae4.png)

After:

![image](https://user-images.githubusercontent.com/654645/71595864-4c1fab80-2b0b-11ea-8d4a-2f906306667c.png)

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [x] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: