### PR TITLE
Remove unnecessary TreeIndexView media property

### DIFF
--- a/treemodeladmin/views.py
+++ b/treemodeladmin/views.py
@@ -1,4 +1,3 @@
-from django import forms
 from django.contrib.admin.utils import unquote
 from django.db import models
 from django.shortcuts import get_object_or_404, redirect
@@ -144,12 +143,6 @@ class TreeIndexView(TreeViewParentMixin, IndexView):
     @cached_property
     def child_name_plural(self):
         return self.model_admin.get_child_name_plural()
-
-    @cached_property
-    def media(self):
-        return forms.Media(
-            css={'all': self.model_admin.get_index_view_extra_css()}
-        )
 
     @cached_property
     def child_url_helper(self):


### PR DESCRIPTION
The TreeModelAdmin index view (TreeIndexView) defines [its own `media` property](https://github.com/cfpb/wagtail-treemodeladmin/blob/a28e28f5c59be7b683673df7402a4f18911fc16a/treemodeladmin/views.py#L148-L152), which pulls in the extra CSS from this package. This is unnecessary, because the base ModelAdmin IndexView from which it inherits already provides a `media` property, which pulls in both extra CSS and JS, if specified by inheriting ModelAdmins.

This functionality exists in all versions of Wagtail supported by this package: [1.13](https://github.com/wagtail/wagtail/blob/v1.13/wagtail/contrib/modeladmin/views.py#L251-L256), [2.5](https://github.com/wagtail/wagtail/blob/v2.5/wagtail/contrib/modeladmin/views.py#L261-L266), and [current master](https://github.com/wagtail/wagtail/blob/7fdb06c86cd7fd32e4ff6b85e012daffbe1637e4/wagtail/contrib/modeladmin/views.py#L258-L262).

Removing this not only eliminates duplicate code, but also fixes a problem where TreeModelAdmins can't provide their own JS files, because they aren't included in the `media` property. For example, TreeModelAdmin currently isn't compatible with [wagtail-orderable](https://pypi.org/project/wagtail-orderable/) for this reason. Making this change, and falling back on the default CSS+JS inclusion, allows for customization of TreeModelAdmin JS.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: