### PR TITLE
Support Wagtail 2.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,10 +12,6 @@ matrix:
       python: 3.6
     - env: TOXENV=py36-dj21-wag23 
       python: 3.6
-    - env: TOXENV=py36-dj21-wag24 
-      python: 3.6
-    - env: TOXENV=py36-dj22-wag25 
-      python: 3.6
     - env: TOXENV=py36-dj22-wag27
       python: 3.6
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,6 @@ matrix:
   include:
     - env: TOXENV=lint
       python: 3.6
-    - env: TOXENV=py27-dj111-wag113
-      python: 2.7
     - env: TOXENV=py36-dj111-wag113
       python: 3.6
     - env: TOXENV=py36-dj111-wag22
@@ -17,6 +15,8 @@ matrix:
     - env: TOXENV=py36-dj21-wag24 
       python: 3.6
     - env: TOXENV=py36-dj22-wag25 
+      python: 3.6
+    - env: TOXENV=py36-dj22-wag27
       python: 3.6
 
 install:

--- a/README.md
+++ b/README.md
@@ -20,9 +20,9 @@ Wagtail-TreeModelAdmin is an extension for Wagtail's [ModelAdmin](http://docs.wa
 
 ## Dependencies
 
-- Python 3.6+
-- Django 1.11+, 2.0+
-- Wagtail 1.13+, 2.0+
+- Python 3.6, 3.7, 3.8
+- Django 1.11, 2.0, 2.2
+- Wagtail 1.13, 2.3, 2.7
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Wagtail-TreeModelAdmin is an extension for Wagtail's [ModelAdmin](http://docs.wa
 
 ## Dependencies
 
-- Python 2.7+, 3.6+
+- Python 3.6+
 - Django 1.11+, 2.0+
 - Wagtail 1.13+, 2.0+
 

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open('README.md') as f:
 
 install_requires = [
     'Django>=1.11,<2.3',
-    'wagtail>=1.13,<2.6',
+    'wagtail>=1.13,<2.8',
 ]
 
 
@@ -52,8 +52,6 @@ setup(
         'License :: CC0 1.0 Universal (CC0 1.0) Public Domain Dedication',
         'License :: Public Domain',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',

--- a/setup.py
+++ b/setup.py
@@ -55,5 +55,6 @@ setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
     ]
 )

--- a/tox.ini
+++ b/tox.ini
@@ -4,8 +4,8 @@ envlist=
     lint,
     py{36}-dj{111}-wag{113},
     py{36}-dj{111,20}-wag{22},
-    py{36,37}-dj{21}-wag{23,24}
-    py{36,37}-dj{22}-wag{25,27}
+    py{36,37}-dj{21}-wag{23}
+    py{36,37}-dj{22}-wag{27}
 
 [testenv]
 install_command=pip install -e ".[testing]" -U {opts} {packages}
@@ -19,6 +19,7 @@ setenv=
 basepython=
     py36: python3.6
     py37: python3.7
+    py38: python3.8
 
 deps=
     dj111: Django>=1.11,<1.12

--- a/tox.ini
+++ b/tox.ini
@@ -2,10 +2,10 @@
 skipsdist=True
 envlist=
     lint,
-    py{27,36}-dj{111}-wag{113},
+    py{36}-dj{111}-wag{113},
     py{36}-dj{111,20}-wag{22},
     py{36,37}-dj{21}-wag{23,24}
-    py{36,37}-dj{22}-wag{25}
+    py{36,37}-dj{22}-wag{25,27}
 
 [testenv]
 install_command=pip install -e ".[testing]" -U {opts} {packages}
@@ -17,7 +17,6 @@ setenv=
     DJANGO_SETTINGS_MODULE=treemodeladmin.tests.settings
 
 basepython=
-    py27: python2.7
     py36: python3.6
     py37: python3.7
 
@@ -31,6 +30,7 @@ deps=
     wag23: wagtail>=2.3,<2.4
     wag24: wagtail>=2.4,<2.5
     wag25: wagtail>=2.5,<2.6
+    wag27: wagtail>=2.7,<2.8
 
 [testenv:lint]
 basepython=python3.6


### PR DESCRIPTION
Remove Python 2.7 and add Python 3.8 to:
* README.rst
* setup.py
* tox.ini
* travis.yml
Add support for Wagtail 2.7 to `tox.ini`, `setup.py`, and `travis.yml`