### PR TITLE
Support for testing with Wagtail 2.8 and Python 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,11 +12,11 @@ matrix:
       python: 3.6
     - env: TOXENV=py36-dj20-wag23 
       python: 3.6
-    - env: TOXENV=py36-dj22-wag27
+    - env: TOXENV=py36-dj22-wag28
       python: 3.6
     - env: TOXENV=py38-dj20-wag23
       python: 3.8
-    - env: TOXENV=py38-dj22-wag27
+    - env: TOXENV=py38-dj22-wag28
       python: 3.8
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ matrix:
       python: 3.6
     - env: TOXENV=py36-dj111-wag113
       python: 3.6
-    - env: TOXENV=py36-dj111-wag22
+    - env: TOXENV=py36-dj111-wag23
       python: 3.6
     - env: TOXENV=py36-dj20-wag23 
       python: 3.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,10 @@ matrix:
       python: 3.6
     - env: TOXENV=py36-dj22-wag27
       python: 3.6
+    - env: TOXENV=py38-dj21-wag23
+      python: 3.8
+    - env: TOXENV=py38-dj22-wag27
+      python: 3.8
 
 install:
   pip install tox coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,11 +10,11 @@ matrix:
       python: 3.6
     - env: TOXENV=py36-dj111-wag22
       python: 3.6
-    - env: TOXENV=py36-dj21-wag23 
+    - env: TOXENV=py36-dj20-wag23 
       python: 3.6
     - env: TOXENV=py36-dj22-wag27
       python: 3.6
-    - env: TOXENV=py38-dj21-wag23
+    - env: TOXENV=py38-dj20-wag23
       python: 3.8
     - env: TOXENV=py38-dj22-wag27
       python: 3.8

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ https://github.com/cfpb/wagtail-treemodeladmin/releases
 or, from the command line:
 
 ```
-git show 1.1.0
+git show 1.1.1
 ```
 
-To show the 1.1.0 release changes.
+To show the 1.1.1 release changes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ https://github.com/cfpb/wagtail-treemodeladmin/releases
 or, from the command line:
 
 ```
-git show 1.0.0
+git show 1.1.0
 ```
 
-To show the 1.0.0 release changes.
+To show the 1.1.0 release changes.

--- a/README.md
+++ b/README.md
@@ -20,9 +20,9 @@ Wagtail-TreeModelAdmin is an extension for Wagtail's [ModelAdmin](http://docs.wa
 
 ## Dependencies
 
-- Python 3.6, 3.8
-- Django 1.11, 2.0, 2.2
-- Wagtail 1.13, 2.3, 2.8
+- Python 3
+- Django 1.11, 2.0-2.2
+- Wagtail 1.13, 2.3-2.8
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Wagtail-TreeModelAdmin is an extension for Wagtail's [ModelAdmin](http://docs.wa
 
 - Python 3.6, 3.8
 - Django 1.11, 2.0, 2.2
-- Wagtail 1.13, 2.3, 2.7
+- Wagtail 1.13, 2.3, 2.8
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -20,9 +20,12 @@ Wagtail-TreeModelAdmin is an extension for Wagtail's [ModelAdmin](http://docs.wa
 
 ## Dependencies
 
-- Python 3
-- Django 1.11, 2.0-2.2
-- Wagtail 1.13, 2.3-2.8
+- Python 3.6, 3.8
+- Django 1.11, 2.0, 2.2
+- Wagtail 1.13, 2.3, 2.8
+
+It should be compatible at all intermediate versions, as well.
+If you find that it is not, please [file an issue](issues/new).
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Wagtail-TreeModelAdmin is an extension for Wagtail's [ModelAdmin](http://docs.wa
 
 ## Dependencies
 
-- Python 3.6, 3.7, 3.8
+- Python 3.6, 3.8
 - Django 1.11, 2.0, 2.2
 - Wagtail 1.13, 2.3, 2.7
 

--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ Wagtail-TreeModelAdmin is an extension for Wagtail's [ModelAdmin](http://docs.wa
 - Django 1.11, 2.0, 2.2
 - Wagtail 1.13, 2.3, 2.8
 
-It should be compatible at all intermediate versions, as well.
-If you find that it is not, please [file an issue](issues/new).
+It should be compatible with all intermediate versions, as well.
+If you find that it is not, please [file an issue](https://github.com/cfpb/wagtail-treemodeladmin/issues/new).
 
 ## Installation
 

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open('README.md') as f:
 
 install_requires = [
     'Django>=1.11,<2.3',
-    'wagtail>=1.13,<2.8',
+    'wagtail>=1.13,<2.9',
 ]
 
 

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,6 @@ setup(
         'Framework :: Django',
         'Framework :: Django :: 1.11',
         'Framework :: Django :: 2.0',
-        'Framework :: Django :: 2.1',
         'Framework :: Django :: 2.2',
         'Framework :: Wagtail',
         'Framework :: Wagtail :: 1',

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     long_description=long_description,
     long_description_content_type='text/markdown',
     license='CC0',
-    version='1.1.0',
+    version='1.1.1',
     include_package_data=True,
     packages=find_packages(),
     package_data={

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     long_description=long_description,
     long_description_content_type='text/markdown',
     license='CC0',
-    version='1.0.5',
+    version='1.1.0',
     include_package_data=True,
     packages=find_packages(),
     package_data={

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,6 @@ setup(
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
     ]
 )

--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,7 @@ setup(
         'Framework :: Django',
         'Framework :: Django :: 1.11',
         'Framework :: Django :: 2.0',
+        'Framework :: Django :: 2.1',
         'Framework :: Django :: 2.2',
         'Framework :: Wagtail',
         'Framework :: Wagtail :: 1',
@@ -52,7 +53,5 @@ setup(
         'License :: Public Domain',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.8',
     ]
 )

--- a/tox.ini
+++ b/tox.ini
@@ -22,7 +22,6 @@ basepython=
 deps=
     dj111: Django>=1.11,<1.12
     dj20: Django>=2.0,<2.1
-    dj21: Django>=2.1,<2.2
     dj22: Django>=2.2,<2.3
     wag113: wagtail>=1.13,<1.14
     wag23: wagtail>=2.3,<2.4

--- a/tox.ini
+++ b/tox.ini
@@ -4,8 +4,8 @@ envlist=
     lint,
     py{36}-dj{111}-wag{113},
     py{36}-dj{111,20}-wag{22},
-    py{36,37}-dj{21}-wag{23}
-    py{36,37}-dj{22}-wag{27}
+    py{36,38}-dj{21}-wag{23}
+    py{36,38}-dj{22}-wag{27}
 
 [testenv]
 install_command=pip install -e ".[testing]" -U {opts} {packages}
@@ -18,7 +18,6 @@ setenv=
 
 basepython=
     py36: python3.6
-    py37: python3.7
     py38: python3.8
 
 deps=
@@ -60,7 +59,7 @@ not_skip=__init__.py
 use_parentheses=1
 known_django=django
 known_wagtail=wagtail
-known_future_library=future,six
+known_future_library=future
 default_section=THIRDPARTY
 sections=FUTURE,STDLIB,DJANGO,WAGTAIL,THIRDPARTY,FIRSTPARTY,LOCALFOLDER
 

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ envlist=
     lint,
     py{36}-dj{111}-wag{113},
     py{36}-dj{111,20}-wag{22},
-    py{36,38}-dj{21}-wag{23}
+    py{36,38}-dj{21}-wag{23},
     py{36,38}-dj{22}-wag{27}
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -3,8 +3,7 @@ skipsdist=True
 envlist=
     lint,
     py{36}-dj{111}-wag{113},
-    py{36}-dj{111,20}-wag{22},
-    py{36}-dj{22}-wag{23},
+    py{36}-dj{111,20,22}-wag{23},
     py{36,38}-dj{22}-wag{28}
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -4,8 +4,7 @@ envlist=
     lint,
     py{36}-dj{111}-wag{113},
     py{36}-dj{111,20}-wag{22},
-    py{36,38}-dj{21}-wag{23},
-    py{36,38}-dj{22}-wag{27}
+    py{36,38}-dj{22}-wag{23,27}
 
 [testenv]
 install_command=pip install -e ".[testing]" -U {opts} {packages}
@@ -23,7 +22,6 @@ basepython=
 deps=
     dj111: Django>=1.11,<1.12
     dj20: Django>=2.0,<2.1
-    dj21: Django>=2.1,<2.2
     dj22: Django>=2.2,<2.3
     wag113: wagtail>=1.13,<1.14
     wag22: wagtail>=2.2,<2.3

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,8 @@ envlist=
     lint,
     py{36}-dj{111}-wag{113},
     py{36}-dj{111,20}-wag{22},
-    py{36,38}-dj{22}-wag{23,27}
+    py{36}-dj{22}-wag{23},
+    py{36,38}-dj{22}-wag{28}
 
 [testenv]
 install_command=pip install -e ".[testing]" -U {opts} {packages}
@@ -26,9 +27,7 @@ deps=
     wag113: wagtail>=1.13,<1.14
     wag22: wagtail>=2.2,<2.3
     wag23: wagtail>=2.3,<2.4
-    wag24: wagtail>=2.4,<2.5
-    wag25: wagtail>=2.5,<2.6
-    wag27: wagtail>=2.7,<2.8
+    wag28: wagtail>=2.8,<2.9
 
 [testenv:lint]
 basepython=python3.6

--- a/tox.ini
+++ b/tox.ini
@@ -25,7 +25,6 @@ deps=
     dj21: Django>=2.1,<2.2
     dj22: Django>=2.2,<2.3
     wag113: wagtail>=1.13,<1.14
-    wag22: wagtail>=2.2,<2.3
     wag23: wagtail>=2.3,<2.4
     wag28: wagtail>=2.8,<2.9
 

--- a/tox.ini
+++ b/tox.ini
@@ -23,6 +23,7 @@ basepython=
 deps=
     dj111: Django>=1.11,<1.12
     dj20: Django>=2.0,<2.1
+    dj21: Django>=2.1,<2.2
     dj22: Django>=2.2,<2.3
     wag113: wagtail>=1.13,<1.14
     wag22: wagtail>=2.2,<2.3


### PR DESCRIPTION
Support production version of Python 3.6 and latest version of Python 3.8
Support production version of Wagtail 1.11 and latest version of Wagtail 2.8

## Additions

Add Python 3.8 to `travis.yml`
Add Wagtail 2.8 in:
- `README.md`
- `setup.py`
- `tox.ini`

## Remove Python 3.7 from:

- `README.md`
- `setup.py`
- `tox.ini`

## Testing

$ tox
```
...
  lint: commands succeeded
  py36-dj111-wag113: commands succeeded
  py36-dj111-wag23: commands succeeded
  py36-dj20-wag23: commands succeeded
  py36-dj22-wag23: commands succeeded
  py36-dj22-wag28: commands succeeded
  py38-dj22-wag28: commands succeeded
  congratulations :)
```

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: