### PR TITLE
Remove Wagtail 1.13 support, add Django 2.2 import support, and add Black for autoformatting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,6 @@ matrix:
   include:
     - env: TOXENV=lint
       python: 3.6
-    - env: TOXENV=py36-dj111-wag113
-      python: 3.6
     - env: TOXENV=py36-dj111-wag23
       python: 3.6
     - env: TOXENV=py36-dj20-wag23 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,3 +30,23 @@ tests that validate implemented features and the presence or lack of defects.
 Additionally, the code should follow any stylistic and architectural guidelines
 prescribed by the project. In the absence of such guidelines, mimic the styles
 and patterns in the existing code-base.
+
+
+## Style
+
+This project uses [`black`](https://github.com/psf/black) to format code,
+[`isort`](https://github.com/timothycrosley/isort) to format imports,
+and [`flake8`](https://gitlab.com/pycqa/flake8).
+
+You can format code and imports by calling:
+
+```
+black treemodeladmin
+isort --recursive treemodeladmin
+```
+
+And you can check for style, import order, and other linting by using:
+
+```
+tox -e lint
+```

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Wagtail-TreeModelAdmin is an extension for Wagtail's [ModelAdmin](http://docs.wa
 
 - Python 3.6, 3.8
 - Django 1.11, 2.0, 2.2
-- Wagtail 1.13, 2.3, 2.8
+- Wagtail 2.3, 2.8
 
 It should be compatible with all intermediate versions, as well.
 If you find that it is not, please [file an issue](https://github.com/cfpb/wagtail-treemodeladmin/issues/new).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,24 @@
+[tool.black]
+line-length = 79
+target-version = ['py36', 'py38']
+include = '\.pyi?$'
+exclude = '''
+(
+  /(
+      \.eggs
+    | \.git
+    | \.tox
+    | \*.egg-info
+    | _build
+    | build
+    | dist
+    | migrations
+    | site
+    | \*.json
+    | \*.csv
+  )/
+)
+'''
+
+[build-system]
+requires = ["setuptools", "wheel"]

--- a/setup.py
+++ b/setup.py
@@ -1,57 +1,55 @@
 from setuptools import find_packages, setup
 
 
-with open('README.md') as f:
+with open("README.md") as f:
     long_description = f.read()
 
 
 install_requires = [
-    'Django>=1.11,<2.3',
-    'wagtail>=1.13,<2.9',
+    "Django>=1.11,<2.3",
+    "wagtail>=1.13,<2.9",
 ]
 
 
 testing_extras = [
-    'mock>=2.0.0',
-    'coverage>=3.7.0',
+    "mock>=2.0.0",
+    "coverage>=3.7.0",
 ]
 
 
 setup(
-    name='wagtail-treemodeladmin',
-    url='https://github.com/cfpb/wagtail-treemodeladmin',
-    author='CFPB',
-    author_email='tech@cfpb.gov',
-    description='TreeModelAdmin for Wagtail',
+    name="wagtail-treemodeladmin",
+    url="https://github.com/cfpb/wagtail-treemodeladmin",
+    author="CFPB",
+    author_email="tech@cfpb.gov",
+    description="TreeModelAdmin for Wagtail",
     long_description=long_description,
-    long_description_content_type='text/markdown',
-    license='CC0',
-    version='1.1.1',
+    long_description_content_type="text/markdown",
+    license="CC0",
+    version="1.1.1",
     include_package_data=True,
     packages=find_packages(),
     package_data={
-        'treemodeladmin': [
-            'templates/treemodeladmin/*',
-            'templates/treemodeladmin/includes/*',
-            'static/treemodeladmin/css/*'
+        "treemodeladmin": [
+            "templates/treemodeladmin/*",
+            "templates/treemodeladmin/includes/*",
+            "static/treemodeladmin/css/*",
         ]
     },
     install_requires=install_requires,
-    extras_require={
-        'testing': testing_extras,
-    },
+    extras_require={"testing": testing_extras},
     classifiers=[
-        'Framework :: Django',
-        'Framework :: Django :: 1.11',
-        'Framework :: Django :: 2.0',
-        'Framework :: Django :: 2.1',
-        'Framework :: Django :: 2.2',
-        'Framework :: Wagtail',
-        'Framework :: Wagtail :: 1',
-        'Framework :: Wagtail :: 2',
-        'License :: CC0 1.0 Universal (CC0 1.0) Public Domain Dedication',
-        'License :: Public Domain',
-        'Programming Language :: Python',
-        'Programming Language :: Python :: 3',
-    ]
+        "Framework :: Django",
+        "Framework :: Django :: 1.11",
+        "Framework :: Django :: 2.0",
+        "Framework :: Django :: 2.1",
+        "Framework :: Django :: 2.2",
+        "Framework :: Wagtail",
+        "Framework :: Wagtail :: 1",
+        "Framework :: Wagtail :: 2",
+        "License :: CC0 1.0 Universal (CC0 1.0) Public Domain Dedication",
+        "License :: Public Domain",
+        "Programming Language :: Python",
+        "Programming Language :: Python :: 3",
+    ],
 )

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open("README.md") as f:
 
 install_requires = [
     "Django>=1.11,<2.3",
-    "wagtail>=1.13,<2.9",
+    "wagtail>=2.3,<2.9",
 ]
 
 
@@ -45,7 +45,6 @@ setup(
         "Framework :: Django :: 2.1",
         "Framework :: Django :: 2.2",
         "Framework :: Wagtail",
-        "Framework :: Wagtail :: 1",
         "Framework :: Wagtail :: 2",
         "License :: CC0 1.0 Universal (CC0 1.0) Public Domain Dedication",
         "License :: Public Domain",

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,6 @@
 skipsdist=True
 envlist=
     lint,
-    py{36}-dj{111}-wag{113},
     py{36}-dj{111,20,22}-wag{23},
     py{36,38}-dj{22}-wag{28}
 
@@ -23,7 +22,6 @@ deps=
     dj111: Django>=1.11,<1.12
     dj20: Django>=2.0,<2.1
     dj22: Django>=2.2,<2.3
-    wag113: wagtail>=1.13,<1.14
     wag23: wagtail>=2.3,<2.4
     wag28: wagtail>=2.8,<2.9
 

--- a/tox.ini
+++ b/tox.ini
@@ -30,9 +30,11 @@ deps=
 [testenv:lint]
 basepython=python3.6
 deps=
-    flake8>=2.2.0
-    isort>=4.2.15
+    black
+    flake8
+    isort
 commands=
+    black --check treemodeladmin setup.py
     flake8 .
     isort --check-only --diff --recursive treemodeladmin
 

--- a/treemodeladmin/__init__.py
+++ b/treemodeladmin/__init__.py
@@ -1,1 +1,1 @@
-default_app_config = 'treemodeladmin.apps.WagtailTreeModelAdminAppConfig'
+default_app_config = "treemodeladmin.apps.WagtailTreeModelAdminAppConfig"

--- a/treemodeladmin/apps.py
+++ b/treemodeladmin/apps.py
@@ -3,6 +3,6 @@ from django.utils.translation import ugettext_lazy as _
 
 
 class WagtailTreeModelAdminAppConfig(AppConfig):
-    name = 'treemodeladmin'
-    label = 'wagtailtreemodeladmin'
+    name = "treemodeladmin"
+    label = "wagtailtreemodeladmin"
     verbose_name = _("Wagtail TreeModelAdmin")

--- a/treemodeladmin/helpers.py
+++ b/treemodeladmin/helpers.py
@@ -5,27 +5,26 @@ from wagtail.contrib.modeladmin.helpers import AdminURLHelper, ButtonHelper
 
 
 class TreeAdminURLHelper(AdminURLHelper):
-
     def get_create_url_with_parent(self, parent_field, parent_pk):
-        return '{create_url}?{parent_field}={parent_pk}'.format(
+        return "{create_url}?{parent_field}={parent_pk}".format(
             create_url=self.create_url,
             parent_field=parent_field,
-            parent_pk=quote(parent_pk)
+            parent_pk=quote(parent_pk),
         )
 
     def get_index_url_with_parent(self, parent_field, parent_pk):
-        return '{index_url}?{parent_field}={parent_pk}'.format(
+        return "{index_url}?{parent_field}={parent_pk}".format(
             index_url=self.index_url,
             parent_field=parent_field,
-            parent_pk=quote(parent_pk)
+            parent_pk=quote(parent_pk),
         )
 
-    def crumb(self, parent_field=None, parent_instance=None,
-              specific_instance=None):
+    def crumb(
+        self, parent_field=None, parent_instance=None, specific_instance=None
+    ):
         if parent_field is not None and parent_instance is not None:
             index_url = self.get_index_url_with_parent(
-                parent_field,
-                parent_instance.pk
+                parent_field, parent_instance.pk
             )
         else:
             index_url = self.index_url
@@ -35,26 +34,27 @@ class TreeAdminURLHelper(AdminURLHelper):
         else:
             crumb_text = force_text(self.opts.verbose_name_plural)
 
-        return (
-            index_url,
-            crumb_text
-        )
+        return (index_url, crumb_text)
 
 
 class TreeButtonHelper(ButtonHelper):
-
     def add_button(self, classnames_add=None, classnames_exclude=None):
         return super(TreeButtonHelper, self).add_button(
-            classnames_add=['button-small']
+            classnames_add=["button-small"]
         )
 
-    def get_add_button_with_parent(self, parent_field, parent_pk,
-                                   classnames_add=None,
-                                   classnames_exclude=None):
-        add_button = self.add_button(classnames_add=classnames_add,
-                                     classnames_exclude=classnames_exclude)
-        add_button['url'] = self.url_helper.get_create_url_with_parent(
-            parent_field,
-            parent_pk
+    def get_add_button_with_parent(
+        self,
+        parent_field,
+        parent_pk,
+        classnames_add=None,
+        classnames_exclude=None,
+    ):
+        add_button = self.add_button(
+            classnames_add=classnames_add,
+            classnames_exclude=classnames_exclude,
+        )
+        add_button["url"] = self.url_helper.get_create_url_with_parent(
+            parent_field, parent_pk
         )
         return add_button

--- a/treemodeladmin/options.py
+++ b/treemodeladmin/options.py
@@ -13,13 +13,13 @@ class TreeModelAdmin(ModelAdmin):
     child_field = None
     child_model_admin = None
     child_instance = None
-    parent_field = ''
+    parent_field = ""
     index_view_class = TreeIndexView
     create_view_class = TreeCreateView
     delete_view_class = TreeDeleteView
     edit_view_class = TreeEditView
     index_view_extra_css = []
-    index_template_name = 'treemodeladmin/index.html'
+    index_template_name = "treemodeladmin/index.html"
     button_helper_class = TreeButtonHelper
     url_helper_class = TreeAdminURLHelper
 
@@ -31,14 +31,15 @@ class TreeModelAdmin(ModelAdmin):
 
     def has_child(self):
         return (
-            (self.child_field is not None) and
-            (self.child_model_admin is not None) and
-            hasattr(self.model, self.child_field)
+            (self.child_field is not None)
+            and (self.child_model_admin is not None)
+            and hasattr(self.model, self.child_field)
         )
 
     def has_parent(self):
-        return (self.parent is not None and
-                isinstance(self.parent, TreeModelAdmin))
+        return self.parent is not None and isinstance(
+            self.parent, TreeModelAdmin
+        )
 
     def get_child_field(self):
         if self.has_child():
@@ -58,8 +59,8 @@ class TreeModelAdmin(ModelAdmin):
 
     def get_index_view_extra_css(self):
         css = [
-            'wagtailmodeladmin/css/index.css',
-            'treemodeladmin/css/index.css'
+            "wagtailmodeladmin/css/index.css",
+            "treemodeladmin/css/index.css",
         ]
         css.extend(self.index_view_extra_css)
         return css

--- a/treemodeladmin/templatetags/treemodeladmin_tags.py
+++ b/treemodeladmin/templatetags/treemodeladmin_tags.py
@@ -9,8 +9,9 @@ from wagtail.contrib.modeladmin.templatetags.modeladmin_tags import (
 register = Library()
 
 
-@register.inclusion_tag("treemodeladmin/includes/tree_result_list.html",
-                        takes_context=True)
+@register.inclusion_tag(
+    "treemodeladmin/includes/tree_result_list.html", takes_context=True
+)
 def tree_result_list(context):
     """ Displays the headers and data list together with a link to children """
     context = result_list(context)
@@ -18,22 +19,25 @@ def tree_result_list(context):
 
 
 @register.inclusion_tag(
-    "treemodeladmin/includes/tree_result_row.html", takes_context=True)
+    "treemodeladmin/includes/tree_result_row.html", takes_context=True
+)
 def tree_result_row_display(context, index):
     context = result_row_display(context, index)
-    obj = context['object_list'][index]
-    view = context['view']
+    obj = context["object_list"][index]
+    view = context["view"]
     child_url_helper = view.child_url_helper
 
     if view.has_child_admin:
-        context.update({
-            'children': view.get_children(obj),
-            'child_index_url': child_url_helper.get_index_url_with_parent(
-                view.child_model_admin.parent_field, obj.pk
-            ),
-            'child_create_url': child_url_helper.get_create_url_with_parent(
-                view.child_model_admin.parent_field, obj.pk
-            ),
-        })
+        context.update(
+            {
+                "children": view.get_children(obj),
+                "child_index_url": child_url_helper.get_index_url_with_parent(
+                    view.child_model_admin.parent_field, obj.pk
+                ),
+                "child_create_url": child_url_helper.get_create_url_with_parent(  # noqa
+                    view.child_model_admin.parent_field, obj.pk
+                ),
+            }
+        )
 
     return context

--- a/treemodeladmin/tests/settings.py
+++ b/treemodeladmin/tests/settings.py
@@ -2,8 +2,6 @@ import os
 
 import django
 
-import wagtail
-
 
 DEBUG = True
 
@@ -26,52 +24,25 @@ DATABASES = {
     },
 }
 
-if wagtail.VERSION >= (2, 0):
-    WAGTAIL_APPS = (
-        "wagtail.contrib.forms",
-        "wagtail.contrib.modeladmin",
-        "wagtail.contrib.settings",
-        "wagtail.tests.testapp",
-        "wagtail.admin",
-        "wagtail.core",
-        "wagtail.documents",
-        "wagtail.images",
-        "wagtail.sites",
-        "wagtail.users",
-    )
+WAGTAIL_APPS = (
+    "wagtail.contrib.forms",
+    "wagtail.contrib.modeladmin",
+    "wagtail.contrib.settings",
+    "wagtail.tests.testapp",
+    "wagtail.admin",
+    "wagtail.core",
+    "wagtail.documents",
+    "wagtail.images",
+    "wagtail.sites",
+    "wagtail.users",
+)
 
-    WAGTAIL_MIDDLEWARE = ("wagtail.core.middleware.SiteMiddleware",)
+WAGTAIL_MIDDLEWARE = ("wagtail.core.middleware.SiteMiddleware",)
 
-    WAGTAILADMIN_RICH_TEXT_EDITORS = {
-        "default": {"WIDGET": "wagtail.admin.rich_text.DraftailRichTextArea"},
-        "custom": {
-            "WIDGET": "wagtail.tests.testapp.rich_text.CustomRichTextArea"
-        },
-    }
-else:
-    WAGTAIL_APPS = (
-        "wagtail.contrib.modeladmin",
-        "wagtail.contrib.settings",
-        "wagtail.tests.testapp",
-        "wagtail.wagtailadmin",
-        "wagtail.wagtailcore",
-        "wagtail.wagtaildocs",
-        "wagtail.wagtailforms",
-        "wagtail.wagtailimages",
-        "wagtail.wagtailsites",
-        "wagtail.wagtailusers",
-    )
-
-    WAGTAIL_MIDDLEWARE = "wagtail.wagtailcore.middleware.SiteMiddleware"
-
-    WAGTAILADMIN_RICH_TEXT_EDITORS = {
-        "default": {
-            "WIDGET": "wagtail.wagtailadmin.rich_text.HalloRichTextArea",
-        },
-        "custom": {
-            "WIDGET": "wagtail.tests.testapp.rich_text.CustomRichTextArea"
-        },
-    }
+WAGTAILADMIN_RICH_TEXT_EDITORS = {
+    "default": {"WIDGET": "wagtail.admin.rich_text.DraftailRichTextArea"},
+    "custom": {"WIDGET": "wagtail.tests.testapp.rich_text.CustomRichTextArea"},
+}
 
 if django.VERSION >= (1, 10):
     MIDDLEWARE = (

--- a/treemodeladmin/tests/settings.py
+++ b/treemodeladmin/tests/settings.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 import os
 
 import django

--- a/treemodeladmin/tests/settings.py
+++ b/treemodeladmin/tests/settings.py
@@ -9,133 +9,124 @@ import wagtail
 
 DEBUG = True
 
-ALLOWED_HOSTS = ['*']
+ALLOWED_HOSTS = ["*"]
 
-SECRET_KEY = 'not needed'
+SECRET_KEY = "not needed"
 
-ROOT_URLCONF = 'treemodeladmin.tests.urls'
+ROOT_URLCONF = "treemodeladmin.tests.urls"
 
 DATABASES = {
-    'default': {
-        'ENGINE': os.environ.get(
-            'DATABASE_ENGINE',
-            'django.db.backends.sqlite3'
+    "default": {
+        "ENGINE": os.environ.get(
+            "DATABASE_ENGINE", "django.db.backends.sqlite3"
         ),
-        'NAME': os.environ.get('DATABASE_NAME', 'treemodeladmin.sqlite'),
-        'USER': os.environ.get('DATABASE_USER', None),
-        'PASSWORD': os.environ.get('DATABASE_PASS', None),
-        'HOST': os.environ.get('DATABASE_HOST', None),
-
-        'TEST': {
-            'NAME': os.environ.get('DATABASE_NAME', None),
-        },
+        "NAME": os.environ.get("DATABASE_NAME", "treemodeladmin.sqlite"),
+        "USER": os.environ.get("DATABASE_USER", None),
+        "PASSWORD": os.environ.get("DATABASE_PASS", None),
+        "HOST": os.environ.get("DATABASE_HOST", None),
+        "TEST": {"NAME": os.environ.get("DATABASE_NAME", None)},
     },
 }
 
 if wagtail.VERSION >= (2, 0):
     WAGTAIL_APPS = (
-        'wagtail.contrib.forms',
-        'wagtail.contrib.modeladmin',
-        'wagtail.contrib.settings',
-        'wagtail.tests.testapp',
-        'wagtail.admin',
-        'wagtail.core',
-        'wagtail.documents',
-        'wagtail.images',
-        'wagtail.sites',
-        'wagtail.users',
+        "wagtail.contrib.forms",
+        "wagtail.contrib.modeladmin",
+        "wagtail.contrib.settings",
+        "wagtail.tests.testapp",
+        "wagtail.admin",
+        "wagtail.core",
+        "wagtail.documents",
+        "wagtail.images",
+        "wagtail.sites",
+        "wagtail.users",
     )
 
-    WAGTAIL_MIDDLEWARE = (
-        'wagtail.core.middleware.SiteMiddleware',
-    )
+    WAGTAIL_MIDDLEWARE = ("wagtail.core.middleware.SiteMiddleware",)
 
     WAGTAILADMIN_RICH_TEXT_EDITORS = {
-        'default': {
-            'WIDGET': 'wagtail.admin.rich_text.DraftailRichTextArea'
-        },
-        'custom': {
-            'WIDGET': 'wagtail.tests.testapp.rich_text.CustomRichTextArea'
+        "default": {"WIDGET": "wagtail.admin.rich_text.DraftailRichTextArea"},
+        "custom": {
+            "WIDGET": "wagtail.tests.testapp.rich_text.CustomRichTextArea"
         },
     }
 else:
     WAGTAIL_APPS = (
-        'wagtail.contrib.modeladmin',
-        'wagtail.contrib.settings',
-        'wagtail.tests.testapp',
-        'wagtail.wagtailadmin',
-        'wagtail.wagtailcore',
-        'wagtail.wagtaildocs',
-        'wagtail.wagtailforms',
-        'wagtail.wagtailimages',
-        'wagtail.wagtailsites',
-        'wagtail.wagtailusers',
+        "wagtail.contrib.modeladmin",
+        "wagtail.contrib.settings",
+        "wagtail.tests.testapp",
+        "wagtail.wagtailadmin",
+        "wagtail.wagtailcore",
+        "wagtail.wagtaildocs",
+        "wagtail.wagtailforms",
+        "wagtail.wagtailimages",
+        "wagtail.wagtailsites",
+        "wagtail.wagtailusers",
     )
 
-    WAGTAIL_MIDDLEWARE = (
-        'wagtail.wagtailcore.middleware.SiteMiddleware',
-    )
+    WAGTAIL_MIDDLEWARE = "wagtail.wagtailcore.middleware.SiteMiddleware"
 
     WAGTAILADMIN_RICH_TEXT_EDITORS = {
-        'default': {
-            'WIDGET': 'wagtail.wagtailadmin.rich_text.HalloRichTextArea',
+        "default": {
+            "WIDGET": "wagtail.wagtailadmin.rich_text.HalloRichTextArea",
         },
-        'custom': {
-            'WIDGET': 'wagtail.tests.testapp.rich_text.CustomRichTextArea'
+        "custom": {
+            "WIDGET": "wagtail.tests.testapp.rich_text.CustomRichTextArea"
         },
     }
 
 if django.VERSION >= (1, 10):
     MIDDLEWARE = (
-        'django.middleware.common.CommonMiddleware',
-        'django.contrib.sessions.middleware.SessionMiddleware',
-        'django.middleware.csrf.CsrfViewMiddleware',
-        'django.contrib.auth.middleware.AuthenticationMiddleware',
-        'django.contrib.messages.middleware.MessageMiddleware',
-        'django.middleware.clickjacking.XFrameOptionsMiddleware',
+        "django.middleware.common.CommonMiddleware",
+        "django.contrib.sessions.middleware.SessionMiddleware",
+        "django.middleware.csrf.CsrfViewMiddleware",
+        "django.contrib.auth.middleware.AuthenticationMiddleware",
+        "django.contrib.messages.middleware.MessageMiddleware",
+        "django.middleware.clickjacking.XFrameOptionsMiddleware",
     ) + WAGTAIL_MIDDLEWARE
 else:
     MIDDLEWARE_CLASSES = (
-        'django.middleware.common.CommonMiddleware',
-        'django.contrib.sessions.middleware.SessionMiddleware',
-        'django.middleware.csrf.CsrfViewMiddleware',
-        'django.contrib.auth.middleware.AuthenticationMiddleware',
-        'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
-        'django.contrib.messages.middleware.MessageMiddleware',
-        'django.middleware.clickjacking.XFrameOptionsMiddleware',
+        "django.middleware.common.CommonMiddleware",
+        "django.contrib.sessions.middleware.SessionMiddleware",
+        "django.middleware.csrf.CsrfViewMiddleware",
+        "django.contrib.auth.middleware.AuthenticationMiddleware",
+        "django.contrib.auth.middleware.SessionAuthenticationMiddleware",
+        "django.contrib.messages.middleware.MessageMiddleware",
+        "django.middleware.clickjacking.XFrameOptionsMiddleware",
     ) + WAGTAIL_MIDDLEWARE
 
 INSTALLED_APPS = (
-    'django.contrib.admin',
-    'django.contrib.auth',
-    'django.contrib.contenttypes',
-    'django.contrib.messages',
-    'django.contrib.sessions',
-    'django.contrib.staticfiles',
-    'taggit',
-) + WAGTAIL_APPS + (
-    'treemodeladmin',
-    'treemodeladmin.tests.treemodeladmintest',
+    (
+        "django.contrib.admin",
+        "django.contrib.auth",
+        "django.contrib.contenttypes",
+        "django.contrib.messages",
+        "django.contrib.sessions",
+        "django.contrib.staticfiles",
+        "taggit",
+    )
+    + WAGTAIL_APPS
+    + ("treemodeladmin", "treemodeladmin.tests.treemodeladmintest",)
 )
 
-STATIC_URL = '/static/'
+STATIC_URL = "/static/"
 
 TEMPLATES = [
     {
-        'BACKEND': 'django.template.backends.django.DjangoTemplates',
-        'DIRS': [],
-        'APP_DIRS': True,
-        'OPTIONS': {
-            'context_processors': [
-                'django.template.context_processors.debug',
-                'django.template.context_processors.request',
-                'django.contrib.auth.context_processors.auth',
-                'django.contrib.messages.context_processors.messages',
-                'django.template.context_processors.request',
+        "BACKEND": "django.template.backends.django.DjangoTemplates",
+        "DIRS": [],
+        "APP_DIRS": True,
+        "OPTIONS": {
+            "context_processors": [
+                "django.template.context_processors.debug",
+                "django.template.context_processors.request",
+                "django.contrib.auth.context_processors.auth",
+                "django.contrib.messages.context_processors.messages",
+                "django.template.context_processors.request",
             ],
-            'debug': True,
+            "debug": True,
         },
     },
 ]
 
-WAGTAIL_SITE_NAME = 'Test Site'
+WAGTAIL_SITE_NAME = "Test Site"

--- a/treemodeladmin/tests/test_options.py
+++ b/treemodeladmin/tests/test_options.py
@@ -6,14 +6,14 @@ from treemodeladmin.tests.treemodeladmintest.models import Author, Book
 
 class BookHasParentModelAdmin(TreeModelAdmin):
     model = Book
-    parent_field = 'author'
+    parent_field = "author"
 
 
 class AuthorHasChildModelAdmin(TreeModelAdmin):
     model = Author
-    child_field = 'book_set'
+    child_field = "book_set"
     child_model_admin = BookHasParentModelAdmin
-    index_view_extra_css = ['authors.css']
+    index_view_extra_css = ["authors.css"]
 
 
 class AuthorPlainModelAdmin(TreeModelAdmin):
@@ -21,7 +21,6 @@ class AuthorPlainModelAdmin(TreeModelAdmin):
 
 
 class TestTreeModelAdmin(TestCase):
-
     def setUp(self):
         self.author_model_admin = AuthorHasChildModelAdmin()
         self.book_model_admin = self.author_model_admin.child_instance
@@ -35,11 +34,11 @@ class TestTreeModelAdmin(TestCase):
         self.assertFalse(self.plain_model_admin.has_child())
 
     def test_has_child_no_child_model_admin(self):
-        self.plain_model_admin.child_field = 'book_set'
+        self.plain_model_admin.child_field = "book_set"
         self.assertFalse(self.plain_model_admin.has_child())
 
     def test_has_child_no_child_field_on_model(self):
-        self.plain_model_admin.child_field = 'authored_books'
+        self.plain_model_admin.child_field = "authored_books"
         self.plain_model_admin.child_model_admin = BookHasParentModelAdmin
         self.assertFalse(self.plain_model_admin.has_child())
 
@@ -48,76 +47,56 @@ class TestTreeModelAdmin(TestCase):
         self.assertTrue(self.book_model_admin.has_parent())
 
     def test_get_child_field(self):
-        self.assertEqual(
-            self.author_model_admin.get_child_field(),
-            'book_set'
-        )
+        self.assertEqual(self.author_model_admin.get_child_field(), "book_set")
 
     def test_get_child_field_none(self):
-        self.assertEqual(
-            self.book_model_admin.get_child_field(),
-            None
-        )
+        self.assertEqual(self.book_model_admin.get_child_field(), None)
 
     def test_get_child_name(self):
-        self.assertEqual(
-            self.author_model_admin.get_child_name(),
-            'book'
-        )
+        self.assertEqual(self.author_model_admin.get_child_name(), "book")
 
     def test_get_child_name_none(self):
-        self.assertEqual(
-            self.book_model_admin.get_child_field(),
-            None
-        )
+        self.assertEqual(self.book_model_admin.get_child_field(), None)
 
     def test_get_child_name_plural(self):
         self.assertEqual(
-            self.author_model_admin.get_child_name_plural(),
-            'books'
+            self.author_model_admin.get_child_name_plural(), "books"
         )
 
     def test_get_child_name_plural_none(self):
-        self.assertEqual(
-            self.book_model_admin.get_child_field(),
-            None
-        )
+        self.assertEqual(self.book_model_admin.get_child_field(), None)
 
     def test_get_parent_field(self):
-        self.assertEqual(
-            self.book_model_admin.get_parent_field(),
-            'author'
-        )
+        self.assertEqual(self.book_model_admin.get_parent_field(), "author")
 
     def test_get_parent_field_none(self):
-        self.assertEqual(
-            self.author_model_admin.get_parent_field(),
-            None
-        )
+        self.assertEqual(self.author_model_admin.get_parent_field(), None)
 
     def test_get_index_view_extra_css(self):
         self.assertEqual(
             self.author_model_admin.get_index_view_extra_css(),
-            ['wagtailmodeladmin/css/index.css',
-             'treemodeladmin/css/index.css',
-             'authors.css']
+            [
+                "wagtailmodeladmin/css/index.css",
+                "treemodeladmin/css/index.css",
+                "authors.css",
+            ],
         )
 
     def test_get_index_view_extra_css_none(self):
         self.assertEqual(
             self.plain_model_admin.get_index_view_extra_css(),
-            ['wagtailmodeladmin/css/index.css',
-             'treemodeladmin/css/index.css']
+            [
+                "wagtailmodeladmin/css/index.css",
+                "treemodeladmin/css/index.css",
+            ],
         )
 
     def test_get_admin_urls_for_registration_child(self):
         self.assertEqual(
-            len(self.author_model_admin.get_admin_urls_for_registration()),
-            8
+            len(self.author_model_admin.get_admin_urls_for_registration()), 8
         )
 
     def test_get_admin_urls_for_registration_no_child(self):
         self.assertEqual(
-            len(self.book_model_admin.get_admin_urls_for_registration()),
-            4
+            len(self.book_model_admin.get_admin_urls_for_registration()), 4
         )

--- a/treemodeladmin/tests/test_views.py
+++ b/treemodeladmin/tests/test_views.py
@@ -6,134 +6,133 @@ from treemodeladmin.tests.treemodeladmintest.models import Author, Book
 
 
 class TestAuthorIndexView(TestCase, WagtailTestUtils):
-    fixtures = ['treemodeladmin_test.json']
+    fixtures = ["treemodeladmin_test.json"]
 
     def setUp(self):
         self.user = self.login()
 
     def get(self, **params):
-        return self.client.get('/admin/treemodeladmintest/author/', params)
+        return self.client.get("/admin/treemodeladmintest/author/", params)
 
     def test_author_listing(self):
         response = self.get()
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.context['result_count'], 4)
+        self.assertEqual(response.context["result_count"], 4)
 
     def test_explore_link(self):
         response = self.get()
         self.assertEqual(response.status_code, 200)
-        self.assertContains(response, 'Explore J. R. R. Tolkien\'s books')
-        self.assertContains(response, '/book/?author=1')
+        self.assertContains(response, "Explore J. R. R. Tolkien's books")
+        self.assertContains(response, "/book/?author=1")
 
     def test_add_child_link(self):
         response = self.get()
         self.assertEqual(response.status_code, 200)
-        self.assertContains(response, 'Add a J. R. Hartley book')
-        self.assertContains(response, '/book/create/?author=4')
+        self.assertContains(response, "Add a J. R. Hartley book")
+        self.assertContains(response, "/book/create/?author=4")
 
     def test_has_child_admin(self):
         response = self.get()
-        self.assertTrue(response.context['view'].has_child_admin)
+        self.assertTrue(response.context["view"].has_child_admin)
 
     def test_breadcrumbs(self):
         resposne = self.get()
         self.assertEqual(
-            list(resposne.context['view'].breadcrumbs),
-            [('/admin/treemodeladmintest/author/', 'authors')]
+            list(resposne.context["view"].breadcrumbs),
+            [("/admin/treemodeladmintest/author/", "authors")],
         )
 
 
 class TestAuthorCreateView(TestCase, WagtailTestUtils):
-    fixtures = ['treemodeladmin_test.json']
+    fixtures = ["treemodeladmin_test.json"]
 
     def setUp(self):
         self.user = self.login()
 
     def post(self, post_data):
-        return self.client.post('/admin/treemodeladmintest/author/create/',
-                                post_data)
+        return self.client.post(
+            "/admin/treemodeladmintest/author/create/", post_data
+        )
 
     def test_create_redirects_to_plain_index(self):
-        response = self.post({
-            'name': 'P. G. Wodehouse',
-        })
+        response = self.post({"name": "P. G. Wodehouse"})
 
         # Should redirect back to
-        self.assertRedirects(response,
-                             '/admin/treemodeladmintest/author/')
+        self.assertRedirects(response, "/admin/treemodeladmintest/author/")
 
 
 class TestBookIndexView(TestCase, WagtailTestUtils):
-    fixtures = ['treemodeladmin_test.json']
+    fixtures = ["treemodeladmin_test.json"]
 
     def setUp(self):
         self.user = self.login()
 
     def get(self, **params):
-        return self.client.get('/admin/treemodeladmintest/book/', params)
+        return self.client.get("/admin/treemodeladmintest/book/", params)
 
     def test_book_listing(self):
         response = self.get()
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.context['result_count'], 4)
+        self.assertEqual(response.context["result_count"], 4)
 
     def test_book_listing_filtered(self):
         response = self.get(author=1)
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.context['result_count'], 2)
+        self.assertEqual(response.context["result_count"], 2)
         self.assertEqual(
-            response.context['view'].get_page_title(),
-            'J. R. R. Tolkien'
+            response.context["view"].get_page_title(), "J. R. R. Tolkien"
         )
 
     def test_book_listing_add_link_filtered(self):
         response = self.get(author=1)
         self.assertEqual(response.status_code, 200)
-        self.assertContains(response, '/book/create/?author=1')
+        self.assertContains(response, "/book/create/?author=1")
 
     def test_has_child_admin(self):
         response = self.get(author=1)
-        self.assertTrue(response.context['view'].has_child_admin)
+        self.assertTrue(response.context["view"].has_child_admin)
 
     def test_book_listing_parent_edit_link_filtered(self):
         response = self.get(author=1)
         self.assertEqual(response.status_code, 200)
-        self.assertContains(response, '/author/edit/1')
+        self.assertContains(response, "/author/edit/1")
 
     def test_breadcrumbs(self):
         resposne = self.get()
         self.assertEqual(
-            list(resposne.context['view'].breadcrumbs),
+            list(resposne.context["view"].breadcrumbs),
             [
-                ('/admin/treemodeladmintest/author/', 'authors'),
-                ('/admin/treemodeladmintest/book/', 'books')
-            ]
+                ("/admin/treemodeladmintest/author/", "authors"),
+                ("/admin/treemodeladmintest/book/", "books"),
+            ],
         )
 
     def test_breadcrumbs_with_parent(self):
         resposne = self.get(author=1)
         self.assertEqual(
-            list(resposne.context['view'].breadcrumbs),
+            list(resposne.context["view"].breadcrumbs),
             [
-                ('/admin/treemodeladmintest/author/', 'J. R. R. Tolkien'),
-                ('/admin/treemodeladmintest/book/?author=1', 'books')
-            ]
+                ("/admin/treemodeladmintest/author/", "J. R. R. Tolkien"),
+                ("/admin/treemodeladmintest/book/?author=1", "books"),
+            ],
         )
 
 
 class TestBookCreateView(TestCase, WagtailTestUtils):
-    fixtures = ['treemodeladmin_test.json']
+    fixtures = ["treemodeladmin_test.json"]
 
     def setUp(self):
         self.user = self.login()
 
     def get(self, **params):
-        return self.client.get('/admin/treemodeladmintest/book/create/',
-                               params)
+        return self.client.get(
+            "/admin/treemodeladmintest/book/create/", params
+        )
 
     def post(self, post_data):
-        return self.client.post('/admin/treemodeladmintest/book/create/',
-                                post_data)
+        return self.client.post(
+            "/admin/treemodeladmintest/book/create/", post_data
+        )
 
     def test_book_creation_with_initial_author(self):
         response = self.get(author=1)
@@ -141,71 +140,63 @@ class TestBookCreateView(TestCase, WagtailTestUtils):
         self.assertContains(response, 'value="1" selected')
 
     def test_create_redirects_to_author(self):
-        response = self.post({
-            'title': 'The Silmarilian',
-            'author': 1,
-        })
+        response = self.post({"title": "The Silmarilian", "author": 1})
 
         # Should redirect back to
-        self.assertRedirects(response,
-                             '/admin/treemodeladmintest/book/?author=1')
+        self.assertRedirects(
+            response, "/admin/treemodeladmintest/book/?author=1"
+        )
 
 
 class TestBookEditView(TestCase, WagtailTestUtils):
-    fixtures = ['treemodeladmin_test.json']
+    fixtures = ["treemodeladmin_test.json"]
 
     def setUp(self):
         self.user = self.login()
 
     def post(self, book_id, post_data):
         return self.client.post(
-            '/admin/treemodeladmintest/book/edit/{}/'.format(book_id),
-            post_data
+            "/admin/treemodeladmintest/book/edit/{}/".format(book_id),
+            post_data,
         )
 
     def test_create_redirects_to_author(self):
         response = self.post(
-            1,
-            {
-                'title': 'The Lord of the Rings',
-                'author': 1,
-            }
+            1, {"title": "The Lord of the Rings", "author": 1}
         )
         self.assertRedirects(
-            response,
-            '/admin/treemodeladmintest/book/?author=1'
+            response, "/admin/treemodeladmintest/book/?author=1"
         )
 
 
 class TestBookDeleteView(TestCase, WagtailTestUtils):
-    fixtures = ['treemodeladmin_test.json']
+    fixtures = ["treemodeladmin_test.json"]
 
     def setUp(self):
         self.login()
 
     def post(self, book_id):
         return self.client.post(
-            '/admin/treemodeladmintest/book/delete/{}/'.format(book_id)
+            "/admin/treemodeladmintest/book/delete/{}/".format(book_id)
         )
 
     def test_post(self):
         response = self.post(2)
         self.assertRedirects(
-            response,
-            '/admin/treemodeladmintest/book/?author=1'
+            response, "/admin/treemodeladmintest/book/?author=1"
         )
         self.assertFalse(Book.objects.filter(id=2).exists())
 
 
 class TestAuthorDeleteView(TestCase, WagtailTestUtils):
-    fixtures = ['treemodeladmin_test.json']
+    fixtures = ["treemodeladmin_test.json"]
 
     def setUp(self):
         self.login()
 
     def post(self, author_id):
         return self.client.post(
-            '/admin/treemodeladmintest/author/delete/{}/'.format(author_id)
+            "/admin/treemodeladmintest/author/delete/{}/".format(author_id)
         )
 
     def test_post_with_dependent_object(self):
@@ -213,50 +204,50 @@ class TestAuthorDeleteView(TestCase, WagtailTestUtils):
         self.assertEqual(response.status_code, 200)
         self.assertContains(
             response,
-            "'J. R. R. Tolkien' is currently referenced by other objects"
+            "'J. R. R. Tolkien' is currently referenced by other objects",
         )
         self.assertContains(
-            response,
-            "<li><b>Book:</b> The Lord of the Rings</li>"
+            response, "<li><b>Book:</b> The Lord of the Rings</li>"
         )
         self.assertTrue(Author.objects.filter(id=1).exists())
 
     def test_post_without_dependent_object(self):
         response = self.post(4)
-        self.assertRedirects(response, '/admin/treemodeladmintest/author/')
+        self.assertRedirects(response, "/admin/treemodeladmintest/author/")
         self.assertFalse(Author.objects.filter(id=4).exists())
 
 
 class TestVolumeIndexView(TestCase, WagtailTestUtils):
-    fixtures = ['treemodeladmin_test.json']
+    fixtures = ["treemodeladmin_test.json"]
 
     def setUp(self):
         self.user = self.login()
 
     def get(self, **params):
-        return self.client.get('/admin/treemodeladmintest/volume/', params)
+        return self.client.get("/admin/treemodeladmintest/volume/", params)
 
     def test_has_child_admin(self):
         response = self.get()
-        self.assertFalse(response.context['view'].has_child_admin)
+        self.assertFalse(response.context["view"].has_child_admin)
 
     def test_volume_listing_filtered(self):
         response = self.get(book=1)
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.context['result_count'], 1)
+        self.assertEqual(response.context["result_count"], 1)
         self.assertEqual(
-            response.context['view'].get_page_title(),
-            'The Lord of the Rings'
+            response.context["view"].get_page_title(), "The Lord of the Rings"
         )
 
     def test_breadcrumbs_with_parents(self):
         resposne = self.get(book=1)
         self.assertEqual(
-            list(resposne.context['view'].breadcrumbs),
+            list(resposne.context["view"].breadcrumbs),
             [
-                ('/admin/treemodeladmintest/author/', 'J. R. R. Tolkien'),
-                ('/admin/treemodeladmintest/book/?author=1',
-                 'The Lord of the Rings'),
-                ('/admin/treemodeladmintest/volume/?book=1', 'volumes')
-            ]
+                ("/admin/treemodeladmintest/author/", "J. R. R. Tolkien"),
+                (
+                    "/admin/treemodeladmintest/book/?author=1",
+                    "The Lord of the Rings",
+                ),
+                ("/admin/treemodeladmintest/volume/?book=1", "volumes"),
+            ],
         )

--- a/treemodeladmin/tests/treemodeladmintest/apps.py
+++ b/treemodeladmin/tests/treemodeladmintest/apps.py
@@ -3,6 +3,6 @@ from django.utils.translation import ugettext_lazy as _
 
 
 class TreeModelAdminTestAppConfig(AppConfig):
-    name = 'treemodeladmin.tests.treemodeladmintest'
-    label = 'test_treemodeladmintest'
+    name = "treemodeladmin.tests.treemodeladmintest"
+    label = "test_treemodeladmintest"
     verbose_name = _("Test Tree Model Admin")

--- a/treemodeladmin/tests/treemodeladmintest/migrations/0001_initial.py
+++ b/treemodeladmin/tests/treemodeladmintest/migrations/0001_initial.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-
 from django.db import migrations, models
 import django.db.models.deletion
 

--- a/treemodeladmin/tests/treemodeladmintest/wagtail_hooks.py
+++ b/treemodeladmin/tests/treemodeladmintest/wagtail_hooks.py
@@ -9,24 +9,24 @@ from treemodeladmin.tests.treemodeladmintest.models import Author, Book, Volume
 
 class VolumeModelAdmin(TreeModelAdmin):
     model = Volume
-    parent_field = 'book'
+    parent_field = "book"
 
 
 class BookModelAdmin(TreeModelAdmin):
     model = Book
-    child_field = 'volume_set'
+    child_field = "volume_set"
     child_model_admin = VolumeModelAdmin
-    parent_field = 'author'
+    parent_field = "author"
 
 
 class AuthorModelAdmin(TreeModelAdmin):
     model = Author
-    child_field = 'book_set'
+    child_field = "book_set"
     child_model_admin = BookModelAdmin
 
 
 @modeladmin_register
 class TreeModelAdminTestGroup(ModelAdminGroup):
-    menu_label = 'TreeModelAdmin Test'
-    menu_icon = 'list-ul'
+    menu_label = "TreeModelAdmin Test"
+    menu_icon = "list-ul"
     items = (AuthorModelAdmin,)

--- a/treemodeladmin/tests/urls.py
+++ b/treemodeladmin/tests/urls.py
@@ -1,8 +1,12 @@
-from django.conf.urls import include, url
-
 from wagtail.admin import urls as wagtailadmin_urls
 
 
+try:
+    from django.urls import include, re_path
+except ImportError:
+    from django.conf.urls import include, url as re_path
+
+
 urlpatterns = [
-    url(r"^admin/", include(wagtailadmin_urls)),
+    re_path(r"^admin/", include(wagtailadmin_urls)),
 ]

--- a/treemodeladmin/tests/urls.py
+++ b/treemodeladmin/tests/urls.py
@@ -10,5 +10,5 @@ else:
 
 
 urlpatterns = [
-    url(r'^admin/', include(wagtailadmin_urls)),
+    url(r"^admin/", include(wagtailadmin_urls)),
 ]

--- a/treemodeladmin/tests/urls.py
+++ b/treemodeladmin/tests/urls.py
@@ -1,12 +1,6 @@
 from django.conf.urls import include, url
 
-import wagtail
-
-
-if wagtail.VERSION >= (2, 0):
-    from wagtail.admin import urls as wagtailadmin_urls
-else:
-    from wagtail.wagtailadmin import urls as wagtailadmin_urls
+from wagtail.admin import urls as wagtailadmin_urls
 
 
 urlpatterns = [

--- a/treemodeladmin/views.py
+++ b/treemodeladmin/views.py
@@ -19,7 +19,6 @@ except ImportError:  # pragma: no cover
 
 
 class TreeViewParentMixin(object):
-
     @cached_property
     def parent_model_admin(self):
         if self.model_admin.has_parent():
@@ -38,7 +37,7 @@ class TreeViewParentMixin(object):
     @cached_property
     def parent_instance(self):
         if self.model_admin.has_parent():
-            if getattr(self, 'instance', None) is not None:
+            if getattr(self, "instance", None) is not None:
                 return getattr(self.instance, self.model_admin.parent_field)
 
             if self.request.method == "POST":
@@ -49,8 +48,9 @@ class TreeViewParentMixin(object):
             if self.model_admin.parent_field in params:
                 parent_pk = unquote(params[self.model_admin.parent_field])
                 filter_kwargs = {self.parent_opts.pk.attname: parent_pk}
-                parent_qs = self.parent_model._default_manager.get_queryset(
-                ).filter(**filter_kwargs)
+                parent_qs = self.parent_model._default_manager.get_queryset().filter(  # noqa
+                    **filter_kwargs
+                )
                 return get_object_or_404(parent_qs)
 
     @property
@@ -66,7 +66,7 @@ class TreeViewParentMixin(object):
                 model_admin.url_helper.crumb(
                     parent_field=model_admin.parent_field,
                     parent_instance=parent_instance,
-                    specific_instance=specific_instance
+                    specific_instance=specific_instance,
                 )
             )
 
@@ -74,9 +74,7 @@ class TreeViewParentMixin(object):
                 model_admin = model_admin.parent
                 specific_instance = parent_instance
                 parent_instance = getattr(
-                    parent_instance,
-                    model_admin.parent_field,
-                    None
+                    parent_instance, model_admin.parent_field, None
                 )
             else:
                 model_admin = None
@@ -85,7 +83,6 @@ class TreeViewParentMixin(object):
 
 
 class TreeIndexView(TreeViewParentMixin, IndexView):
-
     def get_queryset(self, request=None):
         qs = super(TreeIndexView, self).get_queryset(request=request)
 
@@ -104,13 +101,15 @@ class TreeIndexView(TreeViewParentMixin, IndexView):
     def get_parent_edit_button(self):
         if self.parent_instance is None:
             return None
-        parent_button_helper_class = \
+        parent_button_helper_class = (
             self.parent_model_admin.get_button_helper_class()
+        )
         parent_button_helper = parent_button_helper_class(
-            self.parent_model_admin, self.request)
+            self.parent_model_admin, self.request
+        )
         return parent_button_helper.edit_button(
             self.parent_instance.pk,
-            classnames_add=['button-secondary', 'button-small']
+            classnames_add=["button-secondary", "button-small"],
         )
 
     def get_children(self, obj):
@@ -151,7 +150,6 @@ class TreeIndexView(TreeViewParentMixin, IndexView):
 
 
 class TreeModelFormMixin(TreeViewParentMixin):
-
     def get_success_url(self):
         if self.parent_instance is not None:
             return self.url_helper.get_index_url_with_parent(
@@ -161,7 +159,6 @@ class TreeModelFormMixin(TreeViewParentMixin):
 
 
 class TreeCreateView(TreeModelFormMixin, CreateView):
-
     def get_initial(self):
         initial = super(TreeCreateView, self).get_initial()
         if self.parent_instance is not None:
@@ -174,7 +171,6 @@ class TreeEditView(TreeModelFormMixin, EditView):
 
 
 class TreeDeleteView(TreeViewParentMixin, DeleteView):
-
     def post(self, request, *args, **kwargs):
         # Unfortunately, ModelAdmin doesn't provide a good way to override the
         # redirect(self.index_url) like the edit/create views. So this is
@@ -188,7 +184,8 @@ class TreeDeleteView(TreeViewParentMixin, DeleteView):
                 index_url = self.index_url
 
             msg = _("{model} '{instance}' deleted.").format(
-                model=self.verbose_name, instance=self.instance)
+                model=self.verbose_name, instance=self.instance
+            )
             self.delete_instance()
             messages.success(request, msg)
 
@@ -196,16 +193,20 @@ class TreeDeleteView(TreeViewParentMixin, DeleteView):
         except models.ProtectedError:
             linked_objects = []
             fields = self.model._meta.fields_map.values()
-            fields = (obj for obj in fields if not isinstance(
-                obj.field, models.fields.related.ManyToManyField))
+            fields = (
+                obj
+                for obj in fields
+                if not isinstance(
+                    obj.field, models.fields.related.ManyToManyField
+                )
+            )
             for rel in fields:
                 if rel.on_delete == models.PROTECT:
                     qs = getattr(self.instance, rel.get_accessor_name())
                     for obj in qs.all():
                         linked_objects.append(obj)
             context = self.get_context_data(
-                protected_error=True,
-                linked_objects=linked_objects
+                protected_error=True, linked_objects=linked_objects
             )
 
         return self.render_to_response(context)

--- a/treemodeladmin/views.py
+++ b/treemodeladmin/views.py
@@ -4,18 +4,13 @@ from django.shortcuts import get_object_or_404, redirect
 from django.utils.functional import cached_property
 from django.utils.translation import ugettext as _
 
+from wagtail.admin import messages
 from wagtail.contrib.modeladmin.views import (
     CreateView,
     DeleteView,
     EditView,
     IndexView,
 )
-
-
-try:  # pragma: no cover
-    from wagtail.admin import messages
-except ImportError:  # pragma: no cover
-    from wagtail.wagtailadmin import messages
 
 
 class TreeViewParentMixin(object):


### PR DESCRIPTION
## Additions
Support for Django 2.2 imports
Add black to tox

## Removals
Support for Wagtail 1.13 in tox and travis
`from __future__ import absolute_import, unicode_literals`

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [x] Passes all existing automated tests