### PR TITLE
Remove the Django requirement from this application

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,15 +6,13 @@ matrix:
   include:
     - env: TOXENV=lint
       python: 3.6
-    - env: TOXENV=py36-dj111-wag23
+    - env: TOXENV=py36-wag23
       python: 3.6
-    - env: TOXENV=py36-dj20-wag23 
+    - env: TOXENV=py36-wag28
       python: 3.6
-    - env: TOXENV=py36-dj22-wag28
-      python: 3.6
-    - env: TOXENV=py38-dj20-wag23
+    - env: TOXENV=py38-wag23
       python: 3.8
-    - env: TOXENV=py38-dj22-wag28
+    - env: TOXENV=py38-wag28
       python: 3.8
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,13 +6,13 @@ matrix:
   include:
     - env: TOXENV=lint
       python: 3.6
-    - env: TOXENV=py36-wag23
+    - env: TOXENV=py36-dj111-wag23
       python: 3.6
-    - env: TOXENV=py36-wag28
+    - env: TOXENV=py36-dj22-wag23
       python: 3.6
-    - env: TOXENV=py38-wag23
-      python: 3.8
-    - env: TOXENV=py38-wag28
+    - env: TOXENV=py36-dj22-wag29
+      python: 3.6
+    - env: TOXENV=py38-dj22-wag29
       python: 3.8
 
 install:

--- a/README.md
+++ b/README.md
@@ -21,7 +21,6 @@ Wagtail-TreeModelAdmin is an extension for Wagtail's [ModelAdmin](http://docs.wa
 ## Dependencies
 
 - Python 3.6, 3.8
-- Django 1.11, 2.0, 2.2
 - Wagtail 2.3, 2.8
 
 It should be compatible with all intermediate versions, as well.

--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ Wagtail-TreeModelAdmin is an extension for Wagtail's [ModelAdmin](http://docs.wa
 ## Dependencies
 
 - Python 3.6, 3.8
-- Wagtail 2.3, 2.8
+- Django 1.11, 2.2
+- Wagtail 2.3, 2.9
 
 It should be compatible with all intermediate versions, as well.
 If you find that it is not, please [file an issue](https://github.com/cfpb/wagtail-treemodeladmin/issues/new).

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md") as f:
 
 
 install_requires = [
-    "wagtail>=2.3,<2.9",
+    "wagtail>=2.3,<2.10",
 ]
 
 
@@ -39,7 +39,8 @@ setup(
     extras_require={"testing": testing_extras},
     classifiers=[
         "Framework :: Django",
-        "Framework :: Django :: 3",
+        "Framework :: Django :: 1.11",
+        "Framework :: Django :: 2.2",
         "Framework :: Wagtail",
         "Framework :: Wagtail :: 2",
         "License :: CC0 1.0 Universal (CC0 1.0) Public Domain Dedication",

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,6 @@ with open("README.md") as f:
 
 
 install_requires = [
-    "Django>=1.11,<2.3",
     "wagtail>=2.3,<2.9",
 ]
 
@@ -26,7 +25,7 @@ setup(
     long_description=long_description,
     long_description_content_type="text/markdown",
     license="CC0",
-    version="1.1.1",
+    version="1.2.0",
     include_package_data=True,
     packages=find_packages(),
     package_data={
@@ -40,10 +39,7 @@ setup(
     extras_require={"testing": testing_extras},
     classifiers=[
         "Framework :: Django",
-        "Framework :: Django :: 1.11",
-        "Framework :: Django :: 2.0",
-        "Framework :: Django :: 2.1",
-        "Framework :: Django :: 2.2",
+        "Framework :: Django :: 3",
         "Framework :: Wagtail",
         "Framework :: Wagtail :: 2",
         "License :: CC0 1.0 Universal (CC0 1.0) Public Domain Dedication",

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 skipsdist=True
 envlist=
     lint,
-    py{36}-dj111-wag23,
+    py{36}-dj{111,22}-wag23,
     py{36,38}-dj22-wag29
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -2,8 +2,8 @@
 skipsdist=True
 envlist=
     lint,
-    py{36}-dj{111,20,22}-wag{23},
-    py{36,38}-dj{22}-wag{28}
+    py{36}--wag23,
+    py{36,38}-wag28
 
 [testenv]
 install_command=pip install -e ".[testing]" -U {opts} {packages}
@@ -19,9 +19,6 @@ basepython=
     py38: python3.8
 
 deps=
-    dj111: Django>=1.11,<1.12
-    dj20: Django>=2.0,<2.1
-    dj22: Django>=2.2,<2.3
     wag23: wagtail>=2.3,<2.4
     wag28: wagtail>=2.8,<2.9
 

--- a/tox.ini
+++ b/tox.ini
@@ -2,8 +2,8 @@
 skipsdist=True
 envlist=
     lint,
-    py{36}--wag23,
-    py{36,38}-wag28
+    py{36}-dj111-wag23,
+    py{36,38}-dj22-wag29
 
 [testenv]
 install_command=pip install -e ".[testing]" -U {opts} {packages}
@@ -19,8 +19,10 @@ basepython=
     py38: python3.8
 
 deps=
+    dj111: Django>=1.11,<1.12
+    dj22:  Django>=2.2,<2.3
     wag23: wagtail>=2.3,<2.4
-    wag28: wagtail>=2.8,<2.9
+    wag29: wagtail>=2.9,<2.10
 
 [testenv:lint]
 basepython=python3.6

--- a/tox.ini
+++ b/tox.ini
@@ -2,8 +2,8 @@
 skipsdist=True
 envlist=
     lint,
-    py{36}-dj{111,22}-wag23,
-    py{36,38}-dj22-wag29
+    py{36}-dj{111,22}-wag{23},
+    py{36,38}-dj{22}-wag{29}
 
 [testenv]
 install_command=pip install -e ".[testing]" -U {opts} {packages}


### PR DESCRIPTION
We should probably only pin Wagtail in this application, and support
the version range for Django that our Wagtail version specifies.