### PR TITLE
Updates to support isort 5.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md") as f:
 
 
 install_requires = [
-    "wagtail~=2.0",
+    "wagtail>=2.3,<2.10",
 ]
 
 
@@ -25,7 +25,7 @@ setup(
     long_description=long_description,
     long_description_content_type="text/markdown",
     license="CC0",
-    version="1.2.0",
+    version="1.2",
     include_package_data=True,
     packages=find_packages(),
     package_data={

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md") as f:
 
 
 install_requires = [
-    "wagtail>=2.3,<2.10",
+    "wagtail~=2.0",
 ]
 
 
@@ -25,7 +25,7 @@ setup(
     long_description=long_description,
     long_description_content_type="text/markdown",
     license="CC0",
-    version="1.2.0",
+    version="1.2.1",
     include_package_data=True,
     packages=find_packages(),
     package_data={
@@ -35,6 +35,7 @@ setup(
             "static/treemodeladmin/css/*",
         ]
     },
+    python_requires=">=3",
     install_requires=install_requires,
     extras_require={"testing": testing_extras},
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
     long_description=long_description,
     long_description_content_type="text/markdown",
     license="CC0",
-    version="1.2.1",
+    version="1.2.0",
     include_package_data=True,
     packages=find_packages(),
     package_data={
@@ -35,7 +35,7 @@ setup(
             "static/treemodeladmin/css/*",
         ]
     },
-    python_requires=">=3",
+    python_requires=">=3.6",
     install_requires=install_requires,
     extras_require={"testing": testing_extras},
     classifiers=[

--- a/tox.ini
+++ b/tox.ini
@@ -33,7 +33,7 @@ deps=
 commands=
     black --check treemodeladmin setup.py
     flake8 .
-    isort --check-only --diff --recursive treemodeladmin
+    isort --check-only --diff treemodeladmin
 
 [flake8]
 ignore=E731,W503,W504
@@ -49,7 +49,6 @@ lines_after_imports=2
 include_trailing_comma=1
 multi_line_output=3
 skip=.tox,migrations
-not_skip=__init__.py
 use_parentheses=1
 known_django=django
 known_wagtail=wagtail


### PR DESCRIPTION
Removed `not_skip` and `recursive` from `tox.ini` to fix
TypeError: __init__() got an unexpected keyword argument 'not_skip'

* recursive
Prior to version 5.0.0, isort wouldn't automatically traverse directories. The --recursive option was necessary to tell it to do so. In 5.0.0 directories are automatically traversed for all Python files, and as such this option is no longer necessary and should simply be removed.

* not_skip
In an earlier version isort had a default skip of __init__.py. To get around that many projects wanted a way to not skip __init__.py or any other files that were automatically skipped in the future by isort. isort no longer has any default skips, so if the value here is __init__.py you can simply remove the setting.

https://timothycrosley.github.io/isort/docs/upgrade_guides/5.0.0/

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Internet Explorer 8, 9, 10, and 11
- [ ] Edge
- [ ] iOS Safari
- [ ] Chrome for Android

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
