### PR TITLE
Release version 1.3.0 to support Django 3.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     long_description=open("README.md", "r", encoding="utf-8").read(),
     long_description_content_type="text/markdown",
     license="CC0",
-    version="1.2.2",
+    version="1.3.0",
     include_package_data=True,
     packages=find_packages(),
     package_data={

--- a/treemodeladmin/tests/settings.py
+++ b/treemodeladmin/tests/settings.py
@@ -60,7 +60,10 @@ INSTALLED_APPS = (
         "taggit",
     )
     + WAGTAIL_APPS
-    + ("treemodeladmin", "treemodeladmin.tests.treemodeladmintest",)
+    + (
+        "treemodeladmin",
+        "treemodeladmin.tests.treemodeladmintest",
+    )
 )
 
 STATIC_URL = "/static/"


### PR DESCRIPTION
Change from patch to minor release version as support for Wagtail 2.3 has been dropped.