### PR TITLE
Support for Wagtail 2.11 release

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,23 +33,23 @@ jobs:
       matrix:
         toxenv:
             - py36-dj22-wag27
-            - py36-dj22-wag210
-            - py36-dj31-wag210
+            - py36-dj22-wag211
+            - py36-dj31-wag211
             - py38-dj22-wag27
-            - py38-dj22-wag210
-            - py38-dj31-wag210
+            - py38-dj22-wag211
+            - py38-dj31-wag211
         include:
           - toxenv: py36-dj22-wag27
             python-version: 3.6
-          - toxenv: py36-dj22-wag210
+          - toxenv: py36-dj22-wag211
             python-version: 3.6
-          - toxenv: py36-dj31-wag210
+          - toxenv: py36-dj31-wag211
             python-version: 3.6
           - toxenv: py38-dj22-wag27
             python-version: 3.8
-          - toxenv: py38-dj22-wag210
+          - toxenv: py38-dj22-wag211
             python-version: 3.8
-          - toxenv: py38-dj31-wag210
+          - toxenv: py38-dj31-wag211
             python-version: 3.8
 
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -72,4 +72,4 @@ jobs:
         env: 
           TOXENV: ${{ matrix.toxenv }}
           COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}"
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -72,3 +72,4 @@ jobs:
         env: 
           TOXENV: ${{ matrix.toxenv }}
           COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}"

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Wagtail-TreeModelAdmin is an extension for Wagtail's [ModelAdmin](http://docs.wa
 
 - Python 3.6+
 - Django 2.2 (LTS), 3.1 (current)
-- Wagtail 2.7 (LTS), 2.10 (current)
+- Wagtail 2.7 (LTS), 2.11 (current)
 
 It should be compatible with all intermediate versions, as well.
 If you find that it is not, please [file an issue](https://github.com/cfpb/wagtail-treemodeladmin/issues/new).

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import find_packages, setup
 
 install_requires = [
-    "wagtail>=2.7,<2.11",
+    "wagtail>=2.7,<2.12",
 ]
 
 testing_extras = ["coverage>=3.7.0"]

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 skipsdist=True
 envlist=
     lint,
-    py{36,38}-dj{22,31}-wag{27,210}
+    py{36,38}-dj{22,31}-wag{27,211}
 
 [testenv]
 install_command=pip install -e ".[testing]" -U {opts} {packages}
@@ -21,7 +21,7 @@ deps=
     dj22:  Django>=2.2,<2.3
     dj31:  Django>=3.1,<3.2
     wag27: wagtail>=2.7,<2.8
-    wag210: wagtail>=2.10,<2.11
+    wag211: wagtail>=2.11,<2.12
 
 [testenv:lint]
 basepython=python3.6


### PR DESCRIPTION
Hi :wave: 

This PR adds support for the latest Wagtail 2.11 release. 

A new 1.4.0 release of this package should be made to PyPi.