### PR TITLE
Fix breadcrumbs in Wagtail 2.11, drop support for Wagtail < 2.11

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,20 +32,20 @@ jobs:
     strategy:
       matrix:
         toxenv:
-            - py36-dj22-wag27
+            - py36-dj22-wag211
             - py36-dj22-waglatest
             - py36-dj31-waglatest
-            - py38-dj22-wag27
+            - py38-dj22-wag211
             - py38-dj22-waglatest
             - py38-dj31-waglatest
         include:
-          - toxenv: py36-dj22-wag27
+          - toxenv: py36-dj22-wag211
             python-version: 3.6
           - toxenv: py36-dj22-waglatest
             python-version: 3.6
           - toxenv: py36-dj31-waglatest
             python-version: 3.6
-          - toxenv: py38-dj22-wag27
+          - toxenv: py38-dj22-wag211
             python-version: 3.8
           - toxenv: py38-dj22-waglatest
             python-version: 3.8

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Wagtail-TreeModelAdmin is an extension for Wagtail's [ModelAdmin](http://docs.wa
 
 - Python 3.6+
 - Django 2.2 (LTS), 3.1 (current)
-- Wagtail 2.7 (LTS), <3 (current)
+- Wagtail 2.11 (LTS), <3 (current)
 
 It should be compatible with all intermediate versions, as well.
 If you find that it is not, please [file an issue](https://github.com/cfpb/wagtail-treemodeladmin/issues/new).

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import find_packages, setup
 
 install_requires = [
-    "wagtail>=2.7,<3",
+    "wagtail>=2.11,<3",
 ]
 
 testing_extras = ["coverage>=3.7.0"]
@@ -15,7 +15,7 @@ setup(
     long_description=open("README.md", "r", encoding="utf-8").read(),
     long_description_content_type="text/markdown",
     license="CC0",
-    version="1.4.0",
+    version="1.5.0",
     include_package_data=True,
     packages=find_packages(),
     package_data={

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 skipsdist=True
 envlist=
     lint,
-    py{36,38}-dj{22,31}-wag{27,latest}
+    py{36,38}-dj{22,31}-wag{211,latest}
 
 [testenv]
 install_command=pip install -e ".[testing]" -U {opts} {packages}
@@ -20,7 +20,7 @@ basepython=
 deps=
     dj22:  Django>=2.2,<2.3
     dj31:  Django>=3.1,<3.2
-    wag27: wagtail>=2.7,<2.8
+    wag211: wagtail>=2.11,<2.12
     waglatest: wagtail<3
 
 [testenv:lint]

--- a/treemodeladmin/templates/treemodeladmin/includes/breadcrumb.html
+++ b/treemodeladmin/templates/treemodeladmin/includes/breadcrumb.html
@@ -1,8 +1,8 @@
-{% load i18n %}
-<ul class="breadcrumb">
-    <li class="home"><a href="{% url 'wagtailadmin_home' %}" class="icon icon-home text-replace">{% trans 'Home' %}</a></li>
+{% load i18n wagtailadmin_tags %}
 
+<ul class="breadcrumb">
+    <li class="home"><a href="{% url 'wagtailadmin_home' %}">{% icon name="home" class_name="home_icon" title=home %}{% icon name="arrow-right" class_name="arrow_right_icon" %}</a></li>
     {% for index_url,name in view.breadcrumbs %}
-        <li><a href="{{ index_url }}">{{ name|capfirst }}</a></li>
+        <li><a href="{{ index_url }}"><span class="title">{{ name|capfirst }}</span>{% icon name="arrow-right" class_name="arrow_right_icon" %}</a></li>
     {% endfor %}
 </ul>


### PR DESCRIPTION
Wagtail 2.11 is the new LTS release, meaning we can drop support for 2.7. This change also uses Wagtail 2.11's SVG arrow icon in our breadcrumbs in the admin, and versions the next release as 1.5.0. 


## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
