### PR TITLE
Support Wagtail 3.x and switch to pyproject.toml

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,12 +8,12 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
 
       - name: Set up Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v4
         with:
-          python-version: 3.9
+          python-version: 3.8
 
       - name: Install dependencies
         run: |
@@ -32,31 +32,22 @@ jobs:
     strategy:
       matrix:
         toxenv:
-            - py36-dj22-wag211
-            - py36-dj22-waglatest
-            - py36-dj32-waglatest
-            - py39-dj22-wag211
-            - py39-dj22-waglatest
-            - py39-dj32-waglatest
+            - py38-dj3-wag2
+            - py38-dj3-wag3
+            - py38-dj3-waglatest
         include:
-          - toxenv: py36-dj22-wag211
-            python-version: 3.6
-          - toxenv: py36-dj22-waglatest
-            python-version: 3.6
-          - toxenv: py36-dj32-waglatest
-            python-version: 3.6
-          - toxenv: py39-dj22-wag211
-            python-version: 3.9
-          - toxenv: py39-dj22-waglatest
-            python-version: 3.9
-          - toxenv: py39-dj32-waglatest
-            python-version: 3.9
+          - toxenv: py38-dj3-wag2
+            python-version: 3.8
+          - toxenv: py38-dj3-wag3
+            python-version: 3.8
+          - toxenv: py38-dj3-waglatest
+            python-version: 3.8
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
 
       - name: Set up Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -68,8 +59,40 @@ jobs:
       - name: Run tox
         run: |
             tox
-            coveralls
         env:
           TOXENV: ${{ matrix.toxenv }}
-          COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Store test coverage
+        uses: actions/upload-artifact@v2
+        with:
+          name: coverage
+          path: .coverage.*
+
+  coverage:
+    name: coverage
+    runs-on: ubuntu-latest
+    needs:
+      - test
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install tox
+
+      - name: Retrieve test coverage
+        uses: actions/download-artifact@v2
+        with:
+          name: coverage
+
+      - name: Check coverage
+        run: tox -e coverage

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -82,7 +82,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.8"
 
       - name: Install dependencies
         run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,11 +5,10 @@ repos:
     - id: black
       args: ["treemodeladmin", "setup.py", "--line-length=79"]
       exclude: migrations
--   repo: https://gitlab.com/pycqa/flake8
-    rev: 4.0.1
+-   repo: https://github.com/charliermarsh/ruff-pre-commit
+    rev: v0.0.188
     hooks:
-    - id: flake8
-      additional_dependencies: [flake8-bugbear==22.1.11]
+      - id: ruff
 -   repo: https://github.com/pycqa/isort
     rev: 5.10.1
     hooks:

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Then visit the Wagtail admin. `Library` will be in the menu, and will give you a
 Wagtail-TreeModelAdmin uses three new attributes on ModelAdmin subclasses to express parent/child relationships:
 
 - `parent_field`: The name of the Django [`ForeignKey`](https://docs.djangoproject.com/en/2.0/ref/models/fields/#django.db.models.ForeignKey) on a child model.
-- `child_field`: The [`related_name`](https://docs.djangoproject.com/en/2.0/ref/models/fields/#django.db.models.ForeignKey.related_name) on a Django `ForeignKey`.
+- `child_field`: The [`related_name`](https://docs.djangoproject.com/en/3.2/ref/models/fields/#django.db.models.ForeignKey.related_name) on a Django `ForeignKey`.
 - `child_model_admin`
 
 Any `TreeModelAdmin` subclass can specify both parent and child relationships. The root of the tree (either the `TreeModelAdmin` included in a `ModelAdminGroup` or the `@modeladmin_register`ed `TreeModelAdmin` subclass) should only include `child_*` fields.

--- a/README.md
+++ b/README.md
@@ -20,9 +20,9 @@ Wagtail-TreeModelAdmin is an extension for Wagtail's [ModelAdmin](http://docs.wa
 
 ## Dependencies
 
-- Python 3.6+
-- Django 2.2 (LTS), 3.1 (current)
-- Wagtail 2.11 (LTS), <3 (current)
+- Python 3.8+
+- Django 3.2 (LTS), 4.1 (current)
+- Wagtail 2.15 (LTS), <4 (current)
 
 It should be compatible with all intermediate versions, as well.
 If you find that it is not, please [file an issue](https://github.com/cfpb/wagtail-treemodeladmin/issues/new).
@@ -48,7 +48,7 @@ pip install wagtail-treemodeladmin
 
 ## Concepts
 
-Wagtail-TreeModelAdmin allows for a Wagtail page explorer-like navigation of Django one-to-many relationships within the Wagtail admin. In doing this, it conceptualizes the Django [`ForeignKey`](https://docs.djangoproject.com/en/2.0/ref/models/fields/#django.db.models.ForeignKey) relationship as one of parents-to-children. The parent is the destination `to` of the `ForeignKey` relationship, the child is the source of the relationship. 
+Wagtail-TreeModelAdmin allows for a Wagtail page explorer-like navigation of Django one-to-many relationships within the Wagtail admin. In doing this, it conceptualizes the Django [`ForeignKey`](https://docs.djangoproject.com/en/2.0/ref/models/fields/#django.db.models.ForeignKey) relationship as one of parents-to-children. The parent is the destination `to` of the `ForeignKey` relationship, the child is the source of the relationship.
 
 Wagtail-TreeModelAdmin is an extension of [Wagtail's ModelAdmin](http://docs.wagtail.io/en/latest/reference/contrib/modeladmin/index.html). It is intended to be used exactly like `ModelAdmin`.
 
@@ -104,7 +104,7 @@ Then visit the Wagtail admin. `Library` will be in the menu, and will give you a
 Wagtail-TreeModelAdmin uses three new attributes on ModelAdmin subclasses to express parent/child relationships:
 
 - `parent_field`: The name of the Django [`ForeignKey`](https://docs.djangoproject.com/en/2.0/ref/models/fields/#django.db.models.ForeignKey) on a child model.
-- `child_field`: The [`related_name`](https://docs.djangoproject.com/en/2.0/ref/models/fields/#django.db.models.ForeignKey.related_name) on a Django `ForeignKey`. 
+- `child_field`: The [`related_name`](https://docs.djangoproject.com/en/2.0/ref/models/fields/#django.db.models.ForeignKey.related_name) on a Django `ForeignKey`.
 - `child_model_admin`
 
 Any `TreeModelAdmin` subclass can specify both parent and child relationships. The root of the tree (either the `TreeModelAdmin` included in a `ModelAdminGroup` or the `@modeladmin_register`ed `TreeModelAdmin` subclass) should only include `child_*` fields.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,53 @@
+[project]
+name = "wagtail-treemodeladmin"
+version = "1.5.0"
+description = "TreeModelAdmin for Wagtail"
+readme = "README.md"
+requires-python = ">=3.8"
+license = {text = "CC0"}
+authors = [
+    {name = "CFPB", email = "tech@cfpb.gov" }
+]
+dependencies = [
+    "wagtail>=2.15,<4",
+]
+classifiers = [
+    "Framework :: Django",
+    "Framework :: Django :: 3.2",
+    "Framework :: Django :: 4",
+    "Framework :: Wagtail",
+    "Framework :: Wagtail :: 2",
+    "Framework :: Wagtail :: 3",
+    "License :: CC0 1.0 Universal (CC0 1.0) Public Domain Dedication",
+    "License :: Public Domain",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+]
+
+[project.optional-dependencies]
+testing = [
+    "coverage[toml]",
+]
+
+[project.urls]
+"Homepage" = "https://github.com/cfpb/wagtail-treemodeladmin"
+"Bug Reports" = "https://github.com/cfpb/wagtail-treemodeladmin/issues"
+"Source" = "https://github.com/cfpb/wagtail-treemodeladmin"
+
+[build-system]
+requires = ["setuptools>=43.0.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools.package-data]
+treemodeladmin = [
+    "templates/treemodeladmin/*",
+    "templates/treemodeladmin/includes/*",
+    "static/treemodeladmin/css/*",
+]
+
 [tool.black]
 line-length = 79
-target-version = ['py36', 'py38']
+target-version = ["py38"]
 include = '\.pyi?$'
 exclude = '''
 (
@@ -14,8 +61,6 @@ exclude = '''
     | dist
     | migrations
     | site
-    | \*.json
-    | \*.csv
   )/
 )
 '''
@@ -37,5 +82,22 @@ sections = [
     "LOCALFOLDER"
 ]
 
-[build-system]
-requires = ["setuptools", "wheel"]
+[tool.ruff]
+exclude = [
+    ".git",
+    ".tox",
+    "__pycache__",
+    "*/migrations/*.py",
+    "*/tests/treemodeladmintest/migrations/*",
+]
+ignore = []
+select = [
+    "E",
+    "F",
+    "W",
+]
+
+[tool.coverage.run]
+omit = [
+    "treemodeladmin/tests/*",
+]

--- a/setup.py
+++ b/setup.py
@@ -1,42 +1,4 @@
-from setuptools import find_packages, setup
+from setuptools import setup
 
-install_requires = [
-    "wagtail>=2.11,<3",
-]
 
-testing_extras = ["coverage>=3.7.0"]
-
-setup(
-    name="wagtail-treemodeladmin",
-    url="https://github.com/cfpb/wagtail-treemodeladmin",
-    author="CFPB",
-    author_email="tech@cfpb.gov",
-    description="TreeModelAdmin for Wagtail",
-    long_description=open("README.md", "r", encoding="utf-8").read(),
-    long_description_content_type="text/markdown",
-    license="CC0",
-    version="1.5.0",
-    include_package_data=True,
-    packages=find_packages(),
-    package_data={
-        "treemodeladmin": [
-            "templates/treemodeladmin/*",
-            "templates/treemodeladmin/includes/*",
-            "static/treemodeladmin/css/*",
-        ]
-    },
-    python_requires=">=3.6",
-    install_requires=install_requires,
-    extras_require={"testing": testing_extras},
-    classifiers=[
-        "Framework :: Django",
-        "Framework :: Django :: 2.2",
-        "Framework :: Django :: 3.1",
-        "Framework :: Wagtail",
-        "Framework :: Wagtail :: 2",
-        "License :: CC0 1.0 Universal (CC0 1.0) Public Domain Dedication",
-        "License :: Public Domain",
-        "Programming Language :: Python",
-        "Programming Language :: Python :: 3",
-    ],
-)
+setup()

--- a/tox.ini
+++ b/tox.ini
@@ -2,60 +2,46 @@
 skipsdist=True
 envlist=
     lint,
-    py{36,39}-dj{22}-wag{211,latest}
-    py{36,39}-dj{32}-wag{latest}
+    py{38,311}-dj{3}-wag{2,3,latest},
+    coverage
 
 [testenv]
 install_command=pip install -e ".[testing]" -U {opts} {packages}
 commands=
-    coverage erase
-    coverage run --source='treemodeladmin' {envbindir}/django-admin test {posargs}
-    coverage report -m
+    python -b -m coverage run --parallel-mode --source='treemodeladmin' {envbindir}/django-admin test {posargs}
 setenv=
     DJANGO_SETTINGS_MODULE=treemodeladmin.tests.settings
 
 basepython=
-    py36: python3.6
-    py39: python3.9
+    py38: python3.8
+    py311: python3.11
 
 deps=
-    dj22:  Django>=2.2,<2.3
-    dj32:  Django>=3.2,<3.3
-    wag211: wagtail>=2.11,<2.12
+    dj3:  Django>=3.2,<4
+    dj4:  Django>=4.1,<5
+    wag2: wagtail>=2.15,<3
+    wag3: wagtail>=3,<4
     waglatest: wagtail<3
 
 [testenv:lint]
-basepython=python3.9
+basepython=python3.8
 deps=
     black
-    flake8
+    ruff
     isort
 commands=
-    black --check treemodeladmin setup.py
-    flake8 treemodeladmin setup.py
+    black --check treemodeladmin
+    ruff treemodeladmin
     isort --check-only --diff treemodeladmin
 
-[flake8]
-ignore=E732,W503,W504
-exclude=
-    .git,
-    .tox,
-    __pycache__,
-    */migrations/*.py,
-    */tests/treemodeladmintest/migrations/*
+[testenv:coverage]
+basepython=python3.8
+deps=
+    coverage[toml]
+    diff_cover
+commands=
+    coverage combine
+    coverage report -m
+    coverage xml
+    diff-cover coverage.xml --compare-branch=origin/main --fail-under=100
 
-[isort]
-combine_as_imports=1
-lines_after_imports=2
-include_trailing_comma=1
-multi_line_output=3
-skip=.tox,migrations
-use_parentheses=1
-known_django=django
-known_wagtail=wagtail
-default_section=THIRDPARTY
-sections=FUTURE,STDLIB,DJANGO,WAGTAIL,THIRDPARTY,FIRSTPARTY,LOCALFOLDER
-
-[coverage:run]
-omit =
-    treemodeladmin/tests/*

--- a/treemodeladmin/static/treemodeladmin/css/index.css
+++ b/treemodeladmin/static/treemodeladmin/css/index.css
@@ -2,20 +2,6 @@ header.hasform {
     margin-bottom: 0;
 }
 
-header .button-small {
-    background-color: transparent;
-    color: #fff;
-    border-color: #358c8b;
-}
-
-header .button-small:hover {
-    background: #358c8b;
-}
-
-header .button.bicolor {
-    background: #358c8b;
-}
-
 .result-list.col12 {
     padding: 0;
 }

--- a/treemodeladmin/tests/settings.py
+++ b/treemodeladmin/tests/settings.py
@@ -1,5 +1,7 @@
 import os
 
+import wagtail
+
 
 DEBUG = True
 
@@ -26,19 +28,39 @@ WAGTAIL_APPS = (
     "wagtail.contrib.forms",
     "wagtail.contrib.modeladmin",
     "wagtail.contrib.settings",
-    "wagtail.tests.testapp",
     "wagtail.admin",
-    "wagtail.core",
     "wagtail.documents",
     "wagtail.images",
     "wagtail.sites",
     "wagtail.users",
 )
 
-WAGTAILADMIN_RICH_TEXT_EDITORS = {
-    "default": {"WIDGET": "wagtail.admin.rich_text.DraftailRichTextArea"},
-    "custom": {"WIDGET": "wagtail.tests.testapp.rich_text.CustomRichTextArea"},
-}
+if wagtail.VERSION >= (3, 0):
+    WAGTAIL_APPS += (
+        "wagtail",
+        "wagtail.test.testapp",
+    )
+
+    WAGTAILADMIN_RICH_TEXT_EDITORS = {
+        "default": {"WIDGET": "wagtail.admin.rich_text.DraftailRichTextArea"},
+        "custom": {
+            "WIDGET": "wagtail.test.testapp.rich_text.CustomRichTextArea"
+        },
+    }
+
+else:
+    WAGTAIL_APPS += (
+        "wagtail.core",
+        "wagtail.tests.testapp",
+    )
+
+    WAGTAILADMIN_RICH_TEXT_EDITORS = {
+        "default": {"WIDGET": "wagtail.admin.rich_text.DraftailRichTextArea"},
+        "custom": {
+            "WIDGET": "wagtail.tests.testapp.rich_text.CustomRichTextArea"
+        },
+    }
+WAGTAILADMIN_BASE_URL = "http://localhost:8000"
 
 MIDDLEWARE = (
     "django.middleware.common.CommonMiddleware",

--- a/treemodeladmin/tests/treemodeladmintest/apps.py
+++ b/treemodeladmin/tests/treemodeladmintest/apps.py
@@ -6,3 +6,4 @@ class TreeModelAdminTestAppConfig(AppConfig):
     name = "treemodeladmin.tests.treemodeladmintest"
     label = "treemodeladmintest"
     verbose_name = _("Test Tree Model Admin")
+    default_auto_field = "django.db.models.AutoField"

--- a/treemodeladmin/tests/treemodeladmintest/apps.py
+++ b/treemodeladmin/tests/treemodeladmintest/apps.py
@@ -1,5 +1,5 @@
 from django.apps import AppConfig
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 
 class TreeModelAdminTestAppConfig(AppConfig):

--- a/treemodeladmin/views.py
+++ b/treemodeladmin/views.py
@@ -2,7 +2,7 @@ from django.contrib.admin.utils import unquote
 from django.db import models
 from django.shortcuts import get_object_or_404, redirect
 from django.utils.functional import cached_property
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 
 from wagtail.admin import messages
 from wagtail.contrib.modeladmin.views import (

--- a/treemodeladmin/views.py
+++ b/treemodeladmin/views.py
@@ -104,7 +104,7 @@ class TreeIndexView(TreeViewParentMixin, IndexView):
         )
         return parent_button_helper.edit_button(
             self.parent_instance.pk,
-            classnames_add=["button-secondary", "button-small"],
+            classnames_add=["button-small"],
         )
 
     def get_children(self, obj):


### PR DESCRIPTION
With [PEP 621 support added to setuptools](https://github.com/pypa/setuptools/pull/2970) last year, and with pip supporting editable installs as of 21.3, we can move to `pyproject.toml` and deprecate `setup.py`. The file remains for legacy pip support.

Because [flake8 does not want to support pyproject.tml yet](https://github.com/PyCQA/flake8/issues/234), unlike all the other tools we use, I’m removing it in favor of [ruff](https://github.com/charliermarsh/ruff).

This change also enables support for Wagtail 3.x by removing the `<3` version pin. This will result in the last release of TreeModelAdmin to support Wagtail < 4.

Wagtail 4.x is not yet supported.


I’ve also brought in some quality-of-life improvements for coverage checking from the Django-Flags tox/GHA setup.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
