### PR TITLE
Add new interactive tox environment

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -56,6 +56,25 @@ known_wagtail=wagtail
 default_section=THIRDPARTY
 sections=FUTURE,STDLIB,DJANGO,WAGTAIL,THIRDPARTY,FIRSTPARTY,LOCALFOLDER
 
+[testenv:interactive]
+basepython=python3.9
+
+deps=
+    Django>=3.2,<3.3
+
+commands_pre=
+    {envbindir}/django-admin makemigrations
+    {envbindir}/django-admin migrate
+    {envbindir}/django-admin shell -c "from django.contrib.auth.models import User;(not User.objects.filter(username='admin').exists()) and User.objects.create_superuser('admin', 'super@example.com', 'changeme')"
+    {envbindir}/django-admin loaddata treemodeladmin/tests/treemodeladmintest/fixtures/treemodeladmin_test.json
+
+commands=
+    {posargs:{envbindir}/django-admin runserver 0.0.0.0:8000}
+
+setenv=
+    DJANGO_SETTINGS_MODULE=treemodeladmin.tests.settings
+    INTERACTIVE=1
+
 [coverage:run]
 omit =
     treemodeladmin/tests/*


### PR DESCRIPTION
This commit adds a new `tox -e interactive` that runs a local test server with test data, to make it easier to test this project.

This is a nice feature that [wagtail-localize](https://www.wagtail-localize.org/#how-to-run-tests) has that I've also added to [wagtail-inventory](https://github.com/cfpb/wagtail-inventory#testing).

## Testing

`tox -e interactive`

## Todos

This project's README doesn't yet have a section about testing. It would make sense for this to go there.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [x] Passes all existing automated tests