### PR TITLE
Support Wagtail 4.2 through 5.1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,20 +31,13 @@ jobs:
 
     strategy:
       matrix:
-        toxenv:
-            - py38-dj3-wag4
-            - py38-dj4-wag4
-            - py38-dj3-waglatest
-            - py38-dj4-waglatest
+        python: ['3.8', '3.11']
+        django: ['3.2', '4.2']
+        wagtail: ['5.0', '5.1']
         include:
-          - toxenv: py38-dj3-wag4
-            python-version: 3.8
-          - toxenv: py38-dj4-wag4
-            python-version: 3.8
-          - toxenv: py38-dj3-waglatest
-            python-version: 3.8
-          - toxenv: py38-dj4-waglatest
-            python-version: 3.8
+          - python: '3.8'
+            django: '3.2'
+            wagtail: '4.2'
 
     steps:
       - uses: actions/checkout@v3
@@ -52,7 +45,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: ${{ matrix.python }}
 
       - name: Install dependencies
         run: |
@@ -63,7 +56,7 @@ jobs:
         run: |
             tox
         env:
-          TOXENV: ${{ matrix.toxenv }}
+          TOXENV: python${{ matrix.python }}-django${{ matrix.django }}-wagtail${{ matrix.wagtail }}
 
       - name: Store test coverage
         uses: actions/upload-artifact@v2

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Wagtail-TreeModelAdmin is an extension for Wagtail's [ModelAdmin](http://docs.wa
 
 - Python 3.8+
 - Django 3.2 (LTS), 4.1 (current)
-- Wagtail 4.0+
+- Wagtail 4.2+,<5.2
 
 It should be compatible with all intermediate versions, as well.
 If you find that it is not, please [file an issue](https://github.com/cfpb/wagtail-treemodeladmin/issues/new).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,14 +9,15 @@ authors = [
     {name = "CFPB", email = "tech@cfpb.gov" }
 ]
 dependencies = [
-    "wagtail>=4",
+    "wagtail>=4.2,<5.2",
 ]
 classifiers = [
     "Framework :: Django",
     "Framework :: Django :: 3.2",
-    "Framework :: Django :: 4",
+    "Framework :: Django :: 4.2",
     "Framework :: Wagtail",
-    "Framework :: Wagtail :: 4",
+    "Framework :: Wagtail :: 4.2",
+    "Framework :: Wagtail :: 5",
     "License :: CC0 1.0 Universal (CC0 1.0) Public Domain Dedication",
     "License :: Public Domain",
     "Programming Language :: Python",

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,8 @@
 skipsdist=True
 envlist=
     lint,
-    py{38,311}-dj{3,4}-wag{4,latest},
+    python{3.8,3.11}-django{3.2}-wagtail{4.2},
+    python{3.8,3.11}-django{3.2,4.2}-wagtail{5.0,5.1},
     coverage
 
 [testenv]
@@ -13,14 +14,15 @@ setenv=
     DJANGO_SETTINGS_MODULE=treemodeladmin.tests.settings
 
 basepython=
-    py38: python3.8
-    py311: python3.11
+    python3.8: python3.8
+    python3.11: python3.11
 
 deps=
-    dj3:  Django>=3.2,<4
-    dj4:  Django>=4.1,<5
-    wag4: wagtail>=4,<5
-    waglatest: wagtail>4
+    django3.2: Django>=3.2,<3.3
+    django4.2: Django>=4.2,<4.3
+    wagtail4.2: wagtail>=4.2,<4.2.4
+    wagtail5.0: wagtail>=5.0,<5.1
+    wagtail5.1: wagtail>=5.1,<5.2
 
 [testenv:lint]
 basepython=python3.8
@@ -48,7 +50,7 @@ commands=
 basepython=python3.8
 
 deps=
-    Django>=3.2,<3.3
+    Django>=4.2,<4.3
 
 commands_pre=
     {envbindir}/django-admin makemigrations

--- a/treemodeladmin/templates/treemodeladmin/includes/breadcrumb.html
+++ b/treemodeladmin/templates/treemodeladmin/includes/breadcrumb.html
@@ -17,7 +17,7 @@ This implementation borrows heavily from `wagtailsnippets/snippets/headers/_base
                 aria-label="{% trans 'Toggle breadcrumbs' %}"
                 aria-expanded="false"
             >
-                {% icon name="breadcrumb-expand" class_name="w-w-4 w-h-4" %}
+                {% icon name="breadcrumb-expand" classname="w-w-4 w-h-4" %}
             </button>
 
             <div class="w-relative w-h-slim-header w-mr-4 w-top-0 w-z-20 w-flex w-items-center w-flex-row w-flex-1 sm:w-flex-none w-transition w-duration-300">
@@ -30,7 +30,7 @@ This implementation borrows heavily from `wagtailsnippets/snippets/headers/_base
                                         {{ name|capfirst }}
                                     </a>
                                     {% if not forloop.last %}
-                                        {% icon name="arrow-right" class_name=icon_classes %}
+                                        {% icon name="arrow-right" classname=icon_classes %}
                                     {% endif %}
                                 </li>
                             {% endfor %}

--- a/treemodeladmin/tests/settings.py
+++ b/treemodeladmin/tests/settings.py
@@ -1,7 +1,5 @@
 import os
 
-import wagtail
-
 
 DEBUG = True
 
@@ -35,33 +33,9 @@ WAGTAIL_APPS = (
     "wagtail.sites",
     "wagtail.users",
     "wagtail.contrib.styleguide",
+    "wagtail",
 )
 
-if wagtail.VERSION >= (3, 0):
-    WAGTAIL_APPS += (
-        "wagtail",
-        "wagtail.test.testapp",
-    )
-
-    WAGTAILADMIN_RICH_TEXT_EDITORS = {
-        "default": {"WIDGET": "wagtail.admin.rich_text.DraftailRichTextArea"},
-        "custom": {
-            "WIDGET": "wagtail.test.testapp.rich_text.CustomRichTextArea"
-        },
-    }
-
-else:
-    WAGTAIL_APPS += (
-        "wagtail.core",
-        "wagtail.tests.testapp",
-    )
-
-    WAGTAILADMIN_RICH_TEXT_EDITORS = {
-        "default": {"WIDGET": "wagtail.admin.rich_text.DraftailRichTextArea"},
-        "custom": {
-            "WIDGET": "wagtail.tests.testapp.rich_text.CustomRichTextArea"
-        },
-    }
 WAGTAILADMIN_BASE_URL = "http://localhost:8000"
 
 MIDDLEWARE = (


### PR DESCRIPTION
This change adds support for Wagtail 4.2 through 5.1. Wagtail 5.2 changes the breadcrumbs implementation in the admin, and support for it will follow separately.

This drops support for Wagtail 4.1.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [x] Passes all existing automated tests