### PR TITLE
Support Wagtail 5.2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,7 @@ jobs:
       matrix:
         python: ['3.8', '3.12']
         django: ['3.2', '4.2']
-        wagtail: ['5.2']
+        wagtail: ['5.1', '5.2']
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.8
+          python-version: 3.12
 
       - name: Install dependencies
         run: |
@@ -31,13 +31,9 @@ jobs:
 
     strategy:
       matrix:
-        python: ['3.8', '3.11']
+        python: ['3.8', '3.12']
         django: ['3.2', '4.2']
-        wagtail: ['5.0', '5.1']
-        include:
-          - python: '3.8'
-            django: '3.2'
-            wagtail: '4.2'
+        wagtail: ['5.2']
 
     steps:
       - uses: actions/checkout@v3
@@ -50,7 +46,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install tox coveralls
+          pip install tox
 
       - name: Run tox
         run: |
@@ -78,7 +74,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.8"
+          python-version: "3.12"
 
       - name: Install dependencies
         run: |

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Wagtail-TreeModelAdmin is an extension for Wagtail's [ModelAdmin](http://docs.wa
 
 - Python 3.8+
 - Django 3.2 (LTS), 4.1 (current)
-- Wagtail 4.2+,<5.2
+- Wagtail 5.2+
 
 It should be compatible with all intermediate versions, as well.
 If you find that it is not, please [file an issue](https://github.com/cfpb/wagtail-treemodeladmin/issues/new).

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 ![TreeModelAdmin illustration with the books and authors example below](treemodeladmin.gif)
 
-Wagtail-TreeModelAdmin is an extension for Wagtail's [ModelAdmin](http://docs.wagtail.io/en/latest/reference/contrib/modeladmin/) that allows for a page explorer-like navigation of Django model relationships within the Wagtail admin.
+Wagtail-TreeModelAdmin is an extension for Wagtail's [wagtail-modeladmin](https://github.com/wagtail-nest/wagtail-modeladmin) that allows for a page explorer-like navigation of Django model relationships within the Wagtail admin.
 
 - [Dependencies](#dependencies)
 - [Installation](#installation)
@@ -23,6 +23,7 @@ Wagtail-TreeModelAdmin is an extension for Wagtail's [ModelAdmin](http://docs.wa
 - Python 3.8+
 - Django 3.2 (LTS), 4.1 (current)
 - Wagtail 5.1+
+- [wagtail-modeladmin](https://github.com/wagtail-nest/wagtail-modeladmin)
 
 It should be compatible with all intermediate versions, as well.
 If you find that it is not, please [file an issue](https://github.com/cfpb/wagtail-treemodeladmin/issues/new).
@@ -35,12 +36,12 @@ If you find that it is not, please [file an issue](https://github.com/cfpb/wagta
 pip install wagtail-treemodeladmin
 ```
 
-2. Add `treemodeladmin` (and `wagtail.contrib.modeladmin` if it's not already) as an installed app in your Django `settings.py`:
+2. Add `treemodeladmin` (and `wagtail_modeladmin` if it's not already) as an installed app in your Django `settings.py`:
 
  ```python
  INSTALLED_APPS = (
      ...
-     'wagtail.contrib.modeladmin',
+     'wagtail_modeladmin',
      'treemodeladmin',
      ...
  )
@@ -50,7 +51,7 @@ pip install wagtail-treemodeladmin
 
 Wagtail-TreeModelAdmin allows for a Wagtail page explorer-like navigation of Django one-to-many relationships within the Wagtail admin. In doing this, it conceptualizes the Django [`ForeignKey`](https://docs.djangoproject.com/en/2.0/ref/models/fields/#django.db.models.ForeignKey) relationship as one of parents-to-children. The parent is the destination `to` of the `ForeignKey` relationship, the child is the source of the relationship.
 
-Wagtail-TreeModelAdmin is an extension of [Wagtail's ModelAdmin](http://docs.wagtail.io/en/latest/reference/contrib/modeladmin/index.html). It is intended to be used exactly like `ModelAdmin`.
+Wagtail-TreeModelAdmin is an extension of [wagtail-modeladmin](https://github.com/wagtail-nest/wagtail-modeladmin). It is intended to be used exactly like `ModelAdmin`.
 
 ## Usage
 
@@ -76,7 +77,7 @@ Then create the `TreeModelAdmin` subclasses and register the root the tree using
 
 ```python
 # libraryapp/wagtail_hooks.py
-from wagtail.contrib.modeladmin.options import modeladmin_register
+from wagtail_modeladmin.options import modeladmin_register
 
 from treemodeladmin.options import TreeModelAdmin
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Wagtail-TreeModelAdmin is an extension for Wagtail's [ModelAdmin](http://docs.wa
 
 - Python 3.8+
 - Django 3.2 (LTS), 4.1 (current)
-- Wagtail 5.2+
+- Wagtail 5.1+
 
 It should be compatible with all intermediate versions, as well.
 If you find that it is not, please [file an issue](https://github.com/cfpb/wagtail-treemodeladmin/issues/new).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ authors = [
     {name = "CFPB", email = "tech@cfpb.gov" }
 ]
 dependencies = [
-    "wagtail>=5.2,<5.3",
+    "wagtail>=5.1,<5.3",
     "wagtail-modeladmin>=1.0",
 ]
 classifiers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,8 @@ authors = [
     {name = "CFPB", email = "tech@cfpb.gov" }
 ]
 dependencies = [
-    "wagtail>=4.2,<5.2",
+    "wagtail>=5.2,<5.3",
+    "wagtail-modeladmin>=1.0",
 ]
 classifiers = [
     "Framework :: Django",

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 skipsdist=True
 envlist=
     lint,
-    python{3.8,3.12}-django{3.2,4.2}-wagtail{5.2},
+    python{3.8,3.12}-django{3.2,4.2}-wagtail{5.1,5.2},
     coverage
 
 [testenv]
@@ -19,6 +19,7 @@ basepython=
 deps=
     django3.2: Django>=3.2,<3.3
     django4.2: Django>=4.2,<4.3
+    wagtail5.1: wagtail>=5.1,<5.2
     wagtail5.2: wagtail>=5.2,<5.3
 
 [testenv:lint]

--- a/tox.ini
+++ b/tox.ini
@@ -2,8 +2,7 @@
 skipsdist=True
 envlist=
     lint,
-    python{3.8,3.11}-django{3.2}-wagtail{4.2},
-    python{3.8,3.11}-django{3.2,4.2}-wagtail{5.0,5.1},
+    python{3.8,3.12}-django{3.2,4.2}-wagtail{5.2},
     coverage
 
 [testenv]
@@ -15,17 +14,15 @@ setenv=
 
 basepython=
     python3.8: python3.8
-    python3.11: python3.11
+    python3.12: python3.12
 
 deps=
     django3.2: Django>=3.2,<3.3
     django4.2: Django>=4.2,<4.3
-    wagtail4.2: wagtail>=4.2,<4.2.4
-    wagtail5.0: wagtail>=5.0,<5.1
-    wagtail5.1: wagtail>=5.1,<5.2
+    wagtail5.2: wagtail>=5.2,<5.3
 
 [testenv:lint]
-basepython=python3.8
+basepython=python3.12
 deps=
     black
     ruff
@@ -36,7 +33,7 @@ commands=
     isort --check-only --diff treemodeladmin
 
 [testenv:coverage]
-basepython=python3.8
+basepython=python3.12
 deps=
     coverage[toml]
     diff_cover
@@ -47,7 +44,7 @@ commands=
     diff-cover coverage.xml --compare-branch=origin/main --fail-under=100
 
 [testenv:interactive]
-basepython=python3.8
+basepython=python3.12
 
 deps=
     Django>=4.2,<4.3

--- a/treemodeladmin/helpers.py
+++ b/treemodeladmin/helpers.py
@@ -1,7 +1,7 @@
 from django.contrib.admin.utils import quote
 from django.utils.encoding import force_str
 
-from wagtail.contrib.modeladmin.helpers import AdminURLHelper, ButtonHelper
+from wagtail_modeladmin.helpers import AdminURLHelper, ButtonHelper
 
 
 class TreeAdminURLHelper(AdminURLHelper):

--- a/treemodeladmin/options.py
+++ b/treemodeladmin/options.py
@@ -1,4 +1,4 @@
-from wagtail.contrib.modeladmin.options import ModelAdmin
+from wagtail_modeladmin.options import ModelAdmin
 
 from treemodeladmin.helpers import TreeAdminURLHelper, TreeButtonHelper
 from treemodeladmin.views import (

--- a/treemodeladmin/templatetags/treemodeladmin_tags.py
+++ b/treemodeladmin/templatetags/treemodeladmin_tags.py
@@ -1,6 +1,6 @@
 from django.template import Library
 
-from wagtail.contrib.modeladmin.templatetags.modeladmin_tags import (
+from wagtail_modeladmin.templatetags.modeladmin_tags import (
     result_list,
     result_row_display,
 )

--- a/treemodeladmin/tests/settings.py
+++ b/treemodeladmin/tests/settings.py
@@ -24,7 +24,6 @@ DATABASES = {
 
 WAGTAIL_APPS = (
     "wagtail.contrib.forms",
-    "wagtail.contrib.modeladmin",
     "wagtail.contrib.settings",
     "wagtail.admin",
     "wagtail.documents",
@@ -34,6 +33,7 @@ WAGTAIL_APPS = (
     "wagtail.users",
     "wagtail.contrib.styleguide",
     "wagtail",
+    "wagtail_modeladmin",
 )
 
 WAGTAILADMIN_BASE_URL = "http://localhost:8000"

--- a/treemodeladmin/tests/test_views.py
+++ b/treemodeladmin/tests/test_views.py
@@ -1,6 +1,6 @@
 from django.test import TestCase
 
-from wagtail.tests.utils import WagtailTestUtils
+from wagtail.test.utils import WagtailTestUtils
 
 from treemodeladmin.tests.treemodeladmintest.models import Author, Book
 

--- a/treemodeladmin/tests/treemodeladmintest/wagtail_hooks.py
+++ b/treemodeladmin/tests/treemodeladmintest/wagtail_hooks.py
@@ -1,7 +1,4 @@
-from wagtail.contrib.modeladmin.options import (
-    ModelAdminGroup,
-    modeladmin_register,
-)
+from wagtail_modeladmin.options import ModelAdminGroup, modeladmin_register
 
 from treemodeladmin.options import TreeModelAdmin
 from treemodeladmin.tests.treemodeladmintest.models import Author, Book, Volume

--- a/treemodeladmin/views.py
+++ b/treemodeladmin/views.py
@@ -5,7 +5,8 @@ from django.utils.functional import cached_property
 from django.utils.translation import gettext as _
 
 from wagtail.admin import messages
-from wagtail.contrib.modeladmin.views import (
+
+from wagtail_modeladmin.views import (
     CreateView,
     DeleteView,
     EditView,


### PR DESCRIPTION
This updates the package with support for Wagtail 5.2, using the external wagtail-modeladmin rather than the deprecated `wagtail.contrib.modeladmin`.

I've also bumped the top-end Python version to 3.12.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
