### PR TITLE
Update PyPI Publishing and GitHub Actions versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,9 +8,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: 3.12
     - name: Install dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,11 +15,11 @@ jobs:
         python-version: 3.12
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip build twine
+        python -m pip install --upgrade pip build
     - name: Build the package
       run: |
         python -m build
     - name: Publish to PyPI
       uses: pypa/gh-action-pypi-publish@v1
       with:
-        password: ${{ secrets.TWINE_API_KEY }}
+        password: ${{ secrets.PYPI_API_KEY }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,5 @@
 name: Publish to PyPI
-on: 
+on:
    release:
      types: [published]
    workflow_dispatch:
@@ -12,16 +12,14 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: 3.11
+        python-version: 3.12
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip build
-        pip install twine wheel
+        python -m pip install --upgrade pip build twine
     - name: Build the package
       run: |
         python -m build
-    - name: Upload to PyPI
-      run: twine upload dist/*
-      env: 
-        TWINE_USERNAME: ${{ secrets.TWINE_USERNAME }}
-        TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
+    - name: Publish to PyPI
+      uses: pypa/gh-action-pypi-publish@v1
+      with:
+        password: ${{ secrets.TWINE_API_KEY }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,10 +8,10 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: 3.8
 
@@ -40,10 +40,10 @@ jobs:
             wagtail: '4.2'
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python }}
 
@@ -59,9 +59,9 @@ jobs:
           TOXENV: python${{ matrix.python }}-django${{ matrix.django }}-wagtail${{ matrix.wagtail }}
 
       - name: Store test coverage
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
-          name: coverage
+          name: coverage-${{ matrix.python }}-${{ matrix.django }}-${{ matrix.wagtail }}
           path: .coverage.*
 
   coverage:
@@ -71,7 +71,7 @@ jobs:
       - test
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -86,9 +86,9 @@ jobs:
           pip install tox
 
       - name: Retrieve test coverage
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
-          name: coverage
+          merge-multiple: true
 
       - name: Check coverage
         run: tox -e coverage


### PR DESCRIPTION
This change updates our PyPI publishing to use API keys by using the official PyPA action and updates the versions of our GitHub Actions used.

This is a first step toward the current PyPI publishing best practices, and our goal for our Python packages should be something like the [PyPA's example GitHub Actions](https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/). However, this is a quick and simple update we can make to this and our other packages to ensure we can continue publishing. 