### PR TITLE
Upgrade wagtail to 6.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,9 +31,9 @@ jobs:
 
     strategy:
       matrix:
-        python: ['3.8', '3.12' ]
-        django: ['4.2' ]
-        wagtail: ['5.1', '5.2', '6.0' ]
+        python: [ '3.8', '3.12' ]
+        django: [ '4.2' ]
+        wagtail: [ '5.1', '5.2', '6.0' ]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,6 @@
 name: test
 
-on: [pull_request, push]
+on: [ pull_request, push ]
 
 jobs:
 
@@ -31,9 +31,9 @@ jobs:
 
     strategy:
       matrix:
-        python: ['3.8', '3.12']
-        django: ['3.2', '4.2']
-        wagtail: ['5.1', '5.2']
+        python: ['3.8', '3.12' ]
+        django: ['4.2' ]
+        wagtail: ['5.1', '5.2', '6.0' ]
 
     steps:
       - uses: actions/checkout@v4
@@ -50,7 +50,7 @@ jobs:
 
       - name: Run tox
         run: |
-            tox
+          tox
         env:
           TOXENV: python${{ matrix.python }}-django${{ matrix.django }}-wagtail${{ matrix.wagtail }}
 

--- a/README.md
+++ b/README.md
@@ -7,21 +7,22 @@
 
 Wagtail-TreeModelAdmin is an extension for Wagtail's [wagtail-modeladmin](https://github.com/wagtail-nest/wagtail-modeladmin) that allows for a page explorer-like navigation of Django model relationships within the Wagtail admin.
 
-- [Dependencies](#dependencies)
-- [Installation](#installation)
-- [Concepts](#concepts)
-- [Usage](#usage)
+- [Wagtail-TreeModelAdmin](#wagtail-treemodeladmin)
+  - [Dependencies](#dependencies)
+  - [Installation](#installation)
+  - [Concepts](#concepts)
+  - [Usage](#usage)
     - [Quickstart](#quickstart)
-- [API](#api)
-- [Getting help](#getting-help)
-- [Getting involved](#getting-involved)
-- [Licensing](#licensing)
-- [Credits and references](#credits-and-references)
+  - [API](#api)
+  - [Getting help](#getting-help)
+  - [Getting involved](#getting-involved)
+  - [Licensing](#licensing)
+  - [Credits and references](#credits-and-references)
 
 ## Dependencies
 
 - Python 3.8+
-- Django 3.2 (LTS), 4.1 (current)
+- Django {>=4.2,<5.0}
 - Wagtail 5.1+
 - [wagtail-modeladmin](https://github.com/wagtail-nest/wagtail-modeladmin)
 
@@ -38,13 +39,13 @@ pip install wagtail-treemodeladmin
 
 2. Add `treemodeladmin` (and `wagtail_modeladmin` if it's not already) as an installed app in your Django `settings.py`:
 
- ```python
- INSTALLED_APPS = (
-     ...
-     'wagtail_modeladmin',
-     'treemodeladmin',
-     ...
- )
+```python
+INSTALLED_APPS = (
+    ...
+    'wagtail_modeladmin',
+    'treemodeladmin',
+    ...
+)
 ```
 
 ## Concepts

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,15 +1,15 @@
 [project]
 name = "wagtail-treemodeladmin"
-version = "1.9.0"
+version = "2.0.0"
 description = "TreeModelAdmin for Wagtail"
 readme = "README.md"
 requires-python = ">=3.8"
-license = {text = "CC0"}
+license = { text = "CC0" }
 authors = [
-    {name = "CFPB", email = "tech@cfpb.gov" }
+    { name = "CFPB", email = "tech@cfpb.gov" }
 ]
 dependencies = [
-    "wagtail>=5.1,<5.3",
+    "wagtail>=5.1,<6.0.1",
     "wagtail-modeladmin>=1.0",
 ]
 classifiers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ authors = [
     { name = "CFPB", email = "tech@cfpb.gov" }
 ]
 dependencies = [
-    "wagtail>=5.1,<6.0.1",
+    "wagtail>=5.1,<7",
     "wagtail-modeladmin>=1.0",
 ]
 classifiers = [

--- a/tox.ini
+++ b/tox.ini
@@ -1,64 +1,64 @@
 [tox]
-skipsdist=True
-envlist=
+skipsdist = True
+envlist =
     lint,
-    python{3.8,3.12}-django{3.2,4.2}-wagtail{5.1,5.2},
+    python{3.8,3.12}-django{4.2}-wagtail{5.1,5.2,6.0},
     coverage
 
 [testenv]
-install_command=pip install -e ".[testing]" -U {opts} {packages}
-commands=
+install_command = pip install -e ".[testing]" -U {opts} {packages}
+commands =
     python -b -m coverage run --parallel-mode --source='treemodeladmin' {envbindir}/django-admin test {posargs}
-setenv=
+setenv =
     DJANGO_SETTINGS_MODULE=treemodeladmin.tests.settings
 
-basepython=
+basepython =
     python3.8: python3.8
     python3.12: python3.12
 
-deps=
-    django3.2: Django>=3.2,<3.3
+deps =
     django4.2: Django>=4.2,<4.3
     wagtail5.1: wagtail>=5.1,<5.2
     wagtail5.2: wagtail>=5.2,<5.3
+    wagtail6.0: wagtail>=6.0,<6.1
 
 [testenv:lint]
-basepython=python3.12
-deps=
+basepython = python3.12
+deps =
     black
     ruff
     isort
-commands=
+commands =
     black --check treemodeladmin
     ruff treemodeladmin
     isort --check-only --diff treemodeladmin
 
 [testenv:coverage]
-basepython=python3.12
-deps=
+basepython = python3.12
+deps =
     coverage[toml]
     diff_cover
-commands=
+commands =
     coverage combine
     coverage report -m
     coverage xml
     diff-cover coverage.xml --compare-branch=origin/main --fail-under=100
 
 [testenv:interactive]
-basepython=python3.12
+basepython = python3.12
 
-deps=
+deps =
     Django>=4.2,<4.3
 
-commands_pre=
+commands_pre =
     {envbindir}/django-admin makemigrations
     {envbindir}/django-admin migrate
     {envbindir}/django-admin shell -c "from django.contrib.auth.models import User;(not User.objects.filter(username='admin').exists()) and User.objects.create_superuser('admin', 'super@example.com', 'changeme')"
     {envbindir}/django-admin loaddata treemodeladmin/tests/treemodeladmintest/fixtures/treemodeladmin_test.json
 
-commands=
+commands =
     {posargs:{envbindir}/django-admin runserver 0.0.0.0:8000}
 
-setenv=
+setenv =
     DJANGO_SETTINGS_MODULE=treemodeladmin.tests.settings
     INTERACTIVE=1


### PR DESCRIPTION
This PR adds support for wagtail==6.0. It also drops support for Django==3.X. 

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested

