### PR TITLE
Update tooling, packaging, and boilerplate

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,17 +1,9 @@
 repos:
--   repo: https://github.com/psf/black
-    rev: 22.3.0
-    hooks:
-    - id: black
-      args: ["treemodeladmin", "setup.py", "--line-length=79"]
-      exclude: migrations
 -   repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.0.188
+    rev: v0.4.1
     hooks:
+      # Run the linter.
       - id: ruff
--   repo: https://github.com/pycqa/isort
-    rev: 5.10.1
-    hooks:
-      - id: isort
-        name: isort (python)
-        args: ["treemodeladmin"]
+        args: [ --fix ]
+      # Run the formatter.
+      - id: ruff-format

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,9 +1,15 @@
 repos:
--   repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.4.1
-    hooks:
-      # Run the linter.
-      - id: ruff
-        args: [ --fix ]
-      # Run the formatter.
-      - id: ruff-format
+-  repo: https://github.com/charliermarsh/ruff-pre-commit
+   rev: v0.4.1
+   hooks:
+     # Run the linter.
+     - id: ruff
+       args: [ --fix ]
+     # Run the formatter.
+     - id: ruff-format
+- repo: https://github.com/PyCQA/bandit
+  rev: 1.7.8
+  hooks:
+    - id: bandit
+      args: ['-c', 'pyproject.toml', '--recursive']
+      additional_dependencies: ['bandit[toml]']

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,15 +34,14 @@ and patterns in the existing code-base.
 
 ## Style
 
-This project uses [`black`](https://github.com/psf/black) to format code,
-[`isort`](https://github.com/timothycrosley/isort) to format imports,
-and [`flake8`](https://gitlab.com/pycqa/flake8).
+This project uses [`ruff`](https://docs.astral.sh/ruff/) to lint and format
+code and imports.
 
 You can format code and imports by calling:
 
 ```
-black treemodeladmin
-isort --recursive treemodeladmin
+ruff format
+ruff check --fix
 ```
 
 And you can check for style, import order, and other linting by using:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,3 +79,9 @@ select = [
 omit = [
     "treemodeladmin/tests/*",
 ]
+
+[tool.bandit]
+exclude_dirs = [
+    "*/tests/*",
+]
+skips = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,10 @@
+[build-system]
+requires = ["setuptools>=63", "setuptools_scm[toml]>=8"]
+build-backend = "setuptools.build_meta"
+
 [project]
 name = "wagtail-treemodeladmin"
-version = "1.9.0"
+dynamic = ["version"]
 description = "TreeModelAdmin for Wagtail"
 readme = "README.md"
 requires-python = ">=3.8"
@@ -35,16 +39,14 @@ testing = [
 "Bug Reports" = "https://github.com/cfpb/wagtail-treemodeladmin/issues"
 "Source" = "https://github.com/cfpb/wagtail-treemodeladmin"
 
-[build-system]
-requires = ["setuptools>=43.0.0", "wheel"]
-build-backend = "setuptools.build_meta"
-
 [tool.setuptools.package-data]
 treemodeladmin = [
     "templates/treemodeladmin/*",
     "templates/treemodeladmin/includes/*",
     "static/treemodeladmin/css/*",
 ]
+
+[tool.setuptools_scm]
 
 [tool.ruff]
 # Use PEP8 line-length
@@ -84,4 +86,3 @@ omit = [
 exclude_dirs = [
     "*/tests/*",
 ]
-skips = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,56 +46,33 @@ treemodeladmin = [
     "static/treemodeladmin/css/*",
 ]
 
-[tool.black]
-line-length = 79
-target-version = ["py38"]
-include = '\.pyi?$'
-exclude = '''
-(
-  /(
-      \.eggs
-    | \.git
-    | \.tox
-    | \*.egg-info
-    | _build
-    | build
-    | dist
-    | migrations
-    | site
-  )/
-)
-'''
-
-[tool.isort]
-profile = "black"
-line_length = 79
-lines_after_imports = 2
-skip = [".tox", "migrations", ".venv", "venv"]
-known_django = ["django"]
-known_wagtail = ["wagtail"]
-default_section = "THIRDPARTY"
-sections = [
-    "STDLIB",
-    "DJANGO",
-    "WAGTAIL",
-    "THIRDPARTY",
-    "FIRSTPARTY",
-    "LOCALFOLDER"
-]
-
 [tool.ruff]
+# Use PEP8 line-length
+line-length = 79
+# Exclude common paths
 exclude = [
     ".git",
     ".tox",
     "__pycache__",
-    "*/migrations/*.py",
-    "*/tests/treemodeladmintest/migrations/*",
+    "**/migrations/*.py",
 ]
+
+[tool.ruff.lint]
 ignore = []
+# Select specific rulesets to use
 select = [
+    # pycodestyle
     "E",
+    # pyflakes
     "F",
-    "W",
+    # flake8-bugbear
+    "B",
+    # pyupgrade
+    "UP",
+    # flake8-simplify
+    "SIM",
+    # isort
+    "I",
 ]
 
 [tool.coverage.run]

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,3 @@
 from setuptools import setup
 
-
 setup()

--- a/tox.ini
+++ b/tox.ini
@@ -25,13 +25,10 @@ deps=
 [testenv:lint]
 basepython=python3.12
 deps=
-    black
     ruff
-    isort
 commands=
-    black --check treemodeladmin
-    ruff treemodeladmin
-    isort --check-only --diff treemodeladmin
+    ruff format --check
+    ruff check treemodeladmin
 
 [testenv:coverage]
 basepython=python3.12

--- a/tox.ini
+++ b/tox.ini
@@ -26,9 +26,11 @@ deps=
 basepython=python3.12
 deps=
     ruff
+    bandit
 commands=
     ruff format --check
     ruff check treemodeladmin
+    bandit -c "pyproject.toml" -r treemodeladmin
 
 [testenv:coverage]
 basepython=python3.12

--- a/treemodeladmin/helpers.py
+++ b/treemodeladmin/helpers.py
@@ -1,23 +1,14 @@
 from django.contrib.admin.utils import quote
 from django.utils.encoding import force_str
-
 from wagtail_modeladmin.helpers import AdminURLHelper, ButtonHelper
 
 
 class TreeAdminURLHelper(AdminURLHelper):
     def get_create_url_with_parent(self, parent_field, parent_pk):
-        return "{create_url}?{parent_field}={parent_pk}".format(
-            create_url=self.create_url,
-            parent_field=parent_field,
-            parent_pk=quote(parent_pk),
-        )
+        return f"{self.create_url}?{parent_field}={quote(parent_pk)}"
 
     def get_index_url_with_parent(self, parent_field, parent_pk):
-        return "{index_url}?{parent_field}={parent_pk}".format(
-            index_url=self.index_url,
-            parent_field=parent_field,
-            parent_pk=quote(parent_pk),
-        )
+        return f"{self.index_url}?{parent_field}={quote(parent_pk)}"
 
     def crumb(
         self, parent_field=None, parent_instance=None, specific_instance=None
@@ -39,9 +30,7 @@ class TreeAdminURLHelper(AdminURLHelper):
 
 class TreeButtonHelper(ButtonHelper):
     def add_button(self, classnames_add=None, classnames_exclude=None):
-        return super(TreeButtonHelper, self).add_button(
-            classnames_add=["button-small"]
-        )
+        return super().add_button(classnames_add=["button-small"])
 
     def get_add_button_with_parent(
         self,

--- a/treemodeladmin/options.py
+++ b/treemodeladmin/options.py
@@ -24,7 +24,7 @@ class TreeModelAdmin(ModelAdmin):
     url_helper_class = TreeAdminURLHelper
 
     def __init__(self, parent=None):
-        super(TreeModelAdmin, self).__init__(parent=parent)
+        super().__init__(parent=parent)
 
         if self.has_child():
             self.child_instance = self.child_model_admin(parent=self)
@@ -65,7 +65,7 @@ class TreeModelAdmin(ModelAdmin):
         return css
 
     def get_admin_urls_for_registration(self, parent=None):
-        urls = super(TreeModelAdmin, self).get_admin_urls_for_registration()
+        urls = super().get_admin_urls_for_registration()
 
         if self.has_child():
             urls = urls + self.child_instance.get_admin_urls_for_registration()

--- a/treemodeladmin/templatetags/treemodeladmin_tags.py
+++ b/treemodeladmin/templatetags/treemodeladmin_tags.py
@@ -1,10 +1,8 @@
 from django.template import Library
-
 from wagtail_modeladmin.templatetags.modeladmin_tags import (
     result_list,
     result_row_display,
 )
-
 
 register = Library()
 

--- a/treemodeladmin/tests/settings.py
+++ b/treemodeladmin/tests/settings.py
@@ -1,6 +1,5 @@
 import os
 
-
 DEBUG = True
 
 ALLOWED_HOSTS = ["*"]

--- a/treemodeladmin/tests/test_views.py
+++ b/treemodeladmin/tests/test_views.py
@@ -1,5 +1,4 @@
 from django.test import TestCase
-
 from wagtail.test.utils import WagtailTestUtils
 
 from treemodeladmin.tests.treemodeladmintest.models import Author, Book
@@ -167,7 +166,7 @@ class TestBookEditView(TestCase, WagtailTestUtils):
 
     def post(self, book_id, post_data):
         return self.client.post(
-            "/admin/treemodeladmintest/book/edit/{}/".format(book_id),
+            f"/admin/treemodeladmintest/book/edit/{book_id}/",
             post_data,
         )
 
@@ -188,7 +187,7 @@ class TestBookDeleteView(TestCase, WagtailTestUtils):
 
     def post(self, book_id):
         return self.client.post(
-            "/admin/treemodeladmintest/book/delete/{}/".format(book_id)
+            f"/admin/treemodeladmintest/book/delete/{book_id}/"
         )
 
     def test_post(self):
@@ -207,7 +206,7 @@ class TestAuthorDeleteView(TestCase, WagtailTestUtils):
 
     def post(self, author_id):
         return self.client.post(
-            "/admin/treemodeladmintest/author/delete/{}/".format(author_id)
+            f"/admin/treemodeladmintest/author/delete/{author_id}/"
         )
 
     def test_post_with_dependent_object(self):

--- a/treemodeladmin/tests/urls.py
+++ b/treemodeladmin/tests/urls.py
@@ -1,6 +1,5 @@
 from wagtail.admin import urls as wagtailadmin_urls
 
-
 try:
     from django.urls import include, re_path
 except ImportError:

--- a/treemodeladmin/views.py
+++ b/treemodeladmin/views.py
@@ -3,9 +3,7 @@ from django.db import models
 from django.shortcuts import get_object_or_404, redirect
 from django.utils.functional import cached_property
 from django.utils.translation import gettext as _
-
 from wagtail.admin import messages
-
 from wagtail_modeladmin.views import (
     CreateView,
     DeleteView,
@@ -14,7 +12,7 @@ from wagtail_modeladmin.views import (
 )
 
 
-class TreeViewParentMixin(object):
+class TreeViewParentMixin:
     @cached_property
     def parent_model_admin(self):
         if self.model_admin.has_parent():
@@ -44,8 +42,10 @@ class TreeViewParentMixin(object):
             if self.model_admin.parent_field in params:
                 parent_pk = unquote(params[self.model_admin.parent_field])
                 filter_kwargs = {self.parent_opts.pk.attname: parent_pk}
-                parent_qs = self.parent_model._default_manager.get_queryset().filter(  # noqa
-                    **filter_kwargs
+                parent_qs = (
+                    self.parent_model._default_manager.get_queryset().filter(  # noqa
+                        **filter_kwargs
+                    )
                 )
                 return get_object_or_404(parent_qs)
 
@@ -78,7 +78,7 @@ class TreeViewParentMixin(object):
 
 class TreeIndexView(TreeViewParentMixin, IndexView):
     def get_queryset(self, request=None):
-        qs = super(TreeIndexView, self).get_queryset(request=request)
+        qs = super().get_queryset(request=request)
 
         if self.parent_instance is not None:
             parent_filter = {
@@ -90,7 +90,7 @@ class TreeIndexView(TreeViewParentMixin, IndexView):
     def get_page_title(self):
         if self.parent_instance is not None:
             return str(self.parent_instance)
-        return super(TreeIndexView, self).get_page_title()
+        return super().get_page_title()
 
     def get_parent_edit_button(self):
         if self.parent_instance is None:
@@ -166,7 +166,7 @@ class TreeModelFormMixin(TreeViewParentMixin):
 
 class TreeCreateView(TreeModelFormMixin, CreateView):
     def get_initial(self):
-        initial = super(TreeCreateView, self).get_initial()
+        initial = super().get_initial()
         if self.parent_instance is not None:
             initial[self.model_admin.parent_field] = self.parent_instance.pk
         return initial


### PR DESCRIPTION
This PR updates our tooling to make a few changes and updates:

- Use Ruff exclusively for formatting, linting, and import-sorting. Ruff can replace Black and isort, and is faster.
- Add Bandit for static security analysis.
- Add setuptools_scm for versioning. This will mean we don't have to manually update a version number in pyproject.toml.
- Update files, etc, that Ruff changes.


## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)