### PR TITLE
Remove upper version pin

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ authors = [
     {name = "CFPB", email = "tech@cfpb.gov" }
 ]
 dependencies = [
-    "wagtail>=5.1,<5.3",
+    "wagtail>=5.1",
     "wagtail-modeladmin>=1.0",
 ]
 classifiers = [


### PR DESCRIPTION
This change removes our upper version pin of Wagtail, enabling (slightly broken) support for Wagtail 6.

With Wagtail 6 there are some additional changes to the breadcrumb and listing templates that we should bring in. The current listing works okay, with the exception of the buttons, but breadcrumbs are entirely broken. The breadcrumbs are a primary means of navigating the model tree, so that'll need to be fixed before this app officially supports Wagtail 6.x.

This change should make this app non-blocking for Wagtail 6.x though.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)