### PR TITLE
Fix filtering by multi-character primary keys

### DIFF
--- a/treemodeladmin/tests/test_views.py
+++ b/treemodeladmin/tests/test_views.py
@@ -17,7 +17,7 @@ class TestAuthorIndexView(TestCase, WagtailTestUtils):
     def test_author_listing(self):
         response = self.get()
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.context["result_count"], 4)
+        self.assertEqual(response.context["result_count"], 5)
 
     def test_explore_link(self):
         response = self.get()
@@ -77,7 +77,7 @@ class TestBookIndexView(TestCase, WagtailTestUtils):
     def test_book_listing(self):
         response = self.get()
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.context["result_count"], 4)
+        self.assertEqual(response.context["result_count"], 5)
 
     def test_book_listing_filtered(self):
         response = self.get(author=1)
@@ -85,6 +85,14 @@ class TestBookIndexView(TestCase, WagtailTestUtils):
         self.assertEqual(response.context["result_count"], 2)
         self.assertEqual(
             response.context["view"].get_page_title(), "J. R. R. Tolkien"
+        )
+
+    def test_book_listing_filtered_multiple_characters(self):
+        response = self.get(author=11)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.context["result_count"], 1)
+        self.assertEqual(
+            response.context["view"].get_page_title(), "Kurt Vonnegut"
         )
 
     def test_book_listing_add_link_filtered(self):

--- a/treemodeladmin/tests/treemodeladmintest/fixtures/treemodeladmin_test.json
+++ b/treemodeladmin/tests/treemodeladmintest/fixtures/treemodeladmin_test.json
@@ -28,6 +28,13 @@
         }
     },
     {
+        "pk": 11,
+        "model": "treemodeladmintest.author",
+        "fields": {
+            "name": "Kurt Vonnegut"
+        }
+    },
+    {
         "pk": 1,
         "model": "treemodeladmintest.book",
         "fields": {
@@ -57,6 +64,14 @@
         "fields": {
             "title": "The Chronicles of Narnia",
             "author_id": 3
+        }
+    },
+    {
+        "pk": 5,
+        "model": "treemodeladmintest.book",
+        "fields": {
+            "title": "Slaughterhouse-Five",
+            "author_id": 11
         }
     },
     {

--- a/treemodeladmin/views.py
+++ b/treemodeladmin/views.py
@@ -1,6 +1,8 @@
+from django import VERSION as DJANGO_VERSION
 from django.contrib.admin.utils import unquote
 from django.db import models
 from django.shortcuts import get_object_or_404, redirect
+from django.utils.datastructures import MultiValueDict
 from django.utils.functional import cached_property
 from django.utils.translation import gettext as _
 
@@ -80,6 +82,13 @@ class TreeViewParentMixin:
 
 class TreeIndexView(TreeViewParentMixin, IndexView):
     def get_queryset(self, request=None):
+        # Workaround needed until wagtail-modeladmin merges
+        # https://github.com/wagtail-nest/wagtail-modeladmin/pull/55.
+        if DJANGO_VERSION >= (5, 0) and isinstance(
+            self.params, MultiValueDict
+        ):
+            self.params = dict(self.params.lists())
+
         qs = super().get_queryset(request=request)
 
         if self.parent_instance is not None:


### PR DESCRIPTION
Filtering by multi-character primary keys is broken in Django 5.0+, for example with a query string like ?author=11.

This is a bug in the wagtail-modeladmin package that wagtail-treemodeladmin relies upon. There is [an open PR to fix](https://github.com/wagtail-nest/wagtail-modeladmin/pull/55) but until that time we need a workaround.

This is related to [this](https://code.djangoproject.com/ticket/35316) Django issue.