### PR TITLE
Add Wagtail 7 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,12 +32,8 @@ jobs:
     strategy:
       matrix:
         python: ['3.12', '3.13']
-        django: ['5.1']
-        wagtail: ['6.3', '6.4']
-        include:
-          - python: '3.10'
-            django: '4.2'
-            wagtail: '6.2'
+        django: ['5.2']
+        wagtail: ['6.3', '6.4', '7.0']
 
     steps:
       - uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -20,9 +20,9 @@ Wagtail-TreeModelAdmin is an extension for Wagtail's [wagtail-modeladmin](https:
 
 ## Dependencies
 
-- Python 3.10+
-- Django  4.2 (LTS)+
-- Wagtail 5.1+
+- Python 3.12+
+- Django  5.2 (LTS)+
+- Wagtail 6.3+
 - [wagtail-modeladmin](https://github.com/wagtail-nest/wagtail-modeladmin)
 
 It should be compatible with all intermediate versions, as well.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,28 +7,25 @@ name = "wagtail-treemodeladmin"
 dynamic = ["version"]
 description = "TreeModelAdmin for Wagtail"
 readme = "README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.12"
 license = {text = "CC0"}
 authors = [
     {name = "CFPB", email = "tech@cfpb.gov" }
 ]
 dependencies = [
-    "wagtail>=5.1",
+    "wagtail>=6.3",
     "wagtail-modeladmin>=1.0",
 ]
 classifiers = [
     "Framework :: Django",
-    "Framework :: Django :: 3.2",
-    "Framework :: Django :: 4.2",
-    "Framework :: Django :: 5.1",
+    "Framework :: Django :: 5.2",
     "Framework :: Wagtail",
-    "Framework :: Wagtail :: 5",
     "Framework :: Wagtail :: 6",
+    "Framework :: Wagtail :: 7",
     "License :: CC0 1.0 Universal (CC0 1.0) Public Domain Dedication",
     "License :: Public Domain",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
 ]

--- a/tox.ini
+++ b/tox.ini
@@ -48,6 +48,7 @@ basepython=python3.13
 
 deps=
     Django>=5.2,<5.3
+    wagtail>=7.0,<7.1
 
 commands_pre=
     {envbindir}/django-admin makemigrations

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 skipsdist=True
 envlist=
     lint,
-    python{3.10,3.12,3.13}-django{4.2,5.1}-wagtail{6.2,6.3,6.4},
+    python{3.12,3.13}-django{5.2}-wagtail{6.3,6.4,7.0},
     coverage
 
 [testenv]
@@ -13,16 +13,14 @@ setenv=
     DJANGO_SETTINGS_MODULE=treemodeladmin.tests.settings
 
 basepython=
-    python3.10: python3.10
     python3.12: python3.12
     python3.13: python3.13
 
 deps=
-    django4.2: Django>=4.2,<4.3
-    django5.1: Django>=5.1,<5.2
-    wagtail6.2: wagtail>=6.2,<6.3
+    django5.2: Django>=5.2,<5.3
     wagtail6.3: wagtail>=6.3,<6.4
     wagtail6.4: wagtail>=6.4,<6.5
+    wagtail7.0: wagtail>=7.0,<7.1
 
 [testenv:lint]
 basepython=python3.13
@@ -49,7 +47,7 @@ commands=
 basepython=python3.13
 
 deps=
-    Django>=4.2,<4.3
+    Django>=5.2,<5.3
 
 commands_pre=
     {envbindir}/django-admin makemigrations


### PR DESCRIPTION
Add support for Wagtail 7.0. Also remove support for out-of-support Python, Django, and Wagtail versions.

## Additions

- Wagtail 7.0 support

## Removals

- Python 3.10 support
- Django 4.2 support
- Wagtail 6.2 support

## Testing

1. Make sure all unit tests pass with `tox`
2. Make sure everything works the same in the UI with `tox -e interactive` for Wagtail 6.3 and Wagtail 7.0 (you'll need to add a line to `deps` in `tox.ini` after line 50 to specify a Wagtail version, either `wagtail>=6.3,<6.4` or `wagtail>=7.0,<7.1`)

## Notes

- We added a workaround for multi-character primary keys in https://github.com/cfpb/wagtail-treemodeladmin/pull/48. The upstream fix for that still hasn't been merged, so we'll keep our fix in place for now.

## Todos

- I vaguely remember breadcrumbs working for treemodeladmin items at one point, maybe? Those aren't showing up in either Wagtail 6.3 or 7.0 (including in production for iRegs on cf.gov), so it looks like those might have been broken for a while. I'll open a separate issue to get breadcrumbs working again since that's outside of the scope of adding Wagtail 7.0 support.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [x] Passes all existing automated tests