### PR TITLE
Fix sorting of index views

### DIFF
--- a/treemodeladmin/tests/test_views.py
+++ b/treemodeladmin/tests/test_views.py
@@ -19,6 +19,28 @@ class TestAuthorIndexView(TestCase, WagtailTestUtils):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.context["result_count"], 5)
 
+    def test_author_listing_sorting(self):
+        response = self.get(o="0")
+        self.assertEqual(response.status_code, 200)
+        result_names = [
+            author.name for author in response.context["object_list"]
+        ]
+        self.assertEqual(
+            result_names,
+            sorted(result_names),
+        )
+
+    def test_author_listing_reverse_sorting(self):
+        response = self.get(o="-0")
+        self.assertEqual(response.status_code, 200)
+        result_names = [
+            author.name for author in response.context["object_list"]
+        ]
+        self.assertEqual(
+            result_names,
+            sorted(result_names, reverse=True),
+        )
+
     def test_explore_link(self):
         response = self.get()
         self.assertEqual(response.status_code, 200)

--- a/treemodeladmin/tests/treemodeladmintest/wagtail_hooks.py
+++ b/treemodeladmin/tests/treemodeladmintest/wagtail_hooks.py
@@ -6,11 +6,13 @@ from treemodeladmin.tests.treemodeladmintest.models import Author, Book, Volume
 
 class VolumeModelAdmin(TreeModelAdmin):
     model = Volume
+    list_display = ("title",)
     parent_field = "book"
 
 
 class BookModelAdmin(TreeModelAdmin):
     model = Book
+    list_display = ("title",)
     child_field = "volume_set"
     child_model_admin = VolumeModelAdmin
     parent_field = "author"
@@ -18,6 +20,7 @@ class BookModelAdmin(TreeModelAdmin):
 
 class AuthorModelAdmin(TreeModelAdmin):
     model = Author
+    list_display = ("name",)
     child_field = "book_set"
     child_model_admin = BookModelAdmin
 

--- a/treemodeladmin/views.py
+++ b/treemodeladmin/views.py
@@ -81,14 +81,19 @@ class TreeViewParentMixin:
 
 
 class TreeIndexView(TreeViewParentMixin, IndexView):
-    def get_queryset(self, request=None):
-        # Workaround needed until wagtail-modeladmin merges
-        # https://github.com/wagtail-nest/wagtail-modeladmin/pull/55.
-        if DJANGO_VERSION >= (5, 0) and isinstance(
-            self.params, MultiValueDict
-        ):
-            self.params = dict(self.params.lists())
+    def get_filters_params(self, params=None):
+        # See https://github.com/wagtail-nest/wagtail-modeladmin/pull/55.
+        # This is needed for filtering by multi-character primary keys.
+        filters_params = super().get_filters_params(params)
 
+        if DJANGO_VERSION >= (5, 0) and isinstance(
+            filters_params, MultiValueDict
+        ):
+            filters_params = dict(filters_params.lists())
+
+        return filters_params
+
+    def get_queryset(self, request=None):
         qs = super().get_queryset(request=request)
 
         if self.parent_instance is not None:


### PR DESCRIPTION
Commit cf55cfbfae6e7f5592bc29dbbd55664d5c69430b attempted to fix filtering by multi-character primary keys, but introduced a bug that broke sorting. This change fixes sorting and maintains the working multi-character PK filtering behavior. A new unit test has been added to cover this behavior.

To test, run

```
tox -e interactive
```

Test sorting with

http://localhost:8000/admin/treemodeladmintest/author/?o=0
http://localhost:8000/admin/treemodeladmintest/author/?o=-0

Test filtering of multi-character PKs with

http://localhost:8000/admin/treemodeladmintest/book/?author=11

All test model views have been updated with a sortable field.