### PR TITLE
Hide parent field in child create/edit views

### DIFF
--- a/treemodeladmin/tests/test_views.py
+++ b/treemodeladmin/tests/test_views.py
@@ -184,7 +184,8 @@ class TestBookCreateView(TestCase, WagtailTestUtils):
     def test_book_creation_with_initial_author(self):
         response = self.get(author=1)
         self.assertEqual(response.status_code, 200)
-        self.assertContains(response, 'value="1" selected')
+        self.assertContains(response, 'type="hidden" name="author" value="1"')
+        self.assertNotContains(response, '<select name="author"')
 
     def test_create_redirects_to_author(self):
         response = self.post({"title": "The Silmarilian", "author": 1})
@@ -201,11 +202,20 @@ class TestBookEditView(TestCase, WagtailTestUtils):
     def setUp(self):
         self.user = self.login()
 
+    def get(self, book_id):
+        return self.client.get(f"/admin/treemodeladmintest/book/edit/{book_id}/")
+
     def post(self, book_id, post_data):
         return self.client.post(
             f"/admin/treemodeladmintest/book/edit/{book_id}/",
             post_data,
         )
+
+    def test_edit_hides_parent_field(self):
+        response = self.get(1)
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'type="hidden" name="author" value="1"')
+        self.assertNotContains(response, '<select name="author"')
 
     def test_create_redirects_to_author(self):
         response = self.post(

--- a/treemodeladmin/views.py
+++ b/treemodeladmin/views.py
@@ -1,4 +1,4 @@
-from django import VERSION as DJANGO_VERSION
+from django import VERSION as DJANGO_VERSION, forms
 from django.contrib.admin.utils import unquote
 from django.db import models
 from django.shortcuts import get_object_or_404, redirect
@@ -172,6 +172,27 @@ class TreeIndexView(TreeViewParentMixin, IndexView):
 
 
 class TreeModelFormMixin(TreeViewParentMixin):
+    def get_form(self):
+        form = super().get_form()
+
+        if self.parent_instance is not None:
+            parent_field = self.model_admin.parent_field
+            if parent_field in form.fields:
+                form.fields[parent_field].widget = forms.HiddenInput()
+                form.fields[parent_field].initial = self.parent_instance.pk
+
+        return form
+
+    def form_valid(self, form):
+        if self.parent_instance is not None:
+            setattr(
+                form.instance,
+                self.model_admin.parent_field,
+                self.parent_instance,
+            )
+
+        return super().form_valid(form)
+
     def get_success_url(self):
         if self.parent_instance is not None:
             return self.url_helper.get_index_url_with_parent(


### PR DESCRIPTION
Fixes #12.

When you create or edit a child object from a parent context, the parent foreign key is already implied, but the form still shows it as an editable dropdown.

This change hides that field on create and edit when a parent is resolved, and forces the parent value on save so users cannot reparent from this screen.

I also added view tests for both create and edit to verify the parent field is rendered as hidden input instead of a select.

I ran `DJANGO_SETTINGS_MODULE=treemodeladmin.tests.settings .venv/bin/django-admin test`.